### PR TITLE
#172 Mastodon Streaming中の通信切断のハンドリング

### DIFF
--- a/Yukari/build.gradle
+++ b/Yukari/build.gradle
@@ -166,7 +166,7 @@ dependencies {
 
     // Mastodon
 //    implementation "com.github.sys1yagi.mastodon4j:mastodon4j:${mastodon4jVersion}"
-    implementation "com.github.shibafu528.mastodon4j:mastodon4j:967337f"
+    implementation "com.github.shibafu528.mastodon4j:mastodon4j:5b315eb"
 
     // パーサ
     implementation 'com.google.code.gson:gson:2.8.1'

--- a/Yukari/src/main/java/shibafu/yukari/twitter/streaming/Stream.java
+++ b/Yukari/src/main/java/shibafu/yukari/twitter/streaming/Stream.java
@@ -5,6 +5,7 @@ import android.content.Intent;
 import android.util.Log;
 
 import shibafu.yukari.R;
+import shibafu.yukari.service.TwitterService;
 import shibafu.yukari.twitter.AuthUserRecord;
 import twitter4j.ConnectionLifeCycleListener;
 import twitter4j.TwitterStream;
@@ -15,11 +16,6 @@ import twitter4j.conf.ConfigurationBuilder;
  * Created by shibafu on 14/02/16.
  */
 public abstract class Stream {
-    public static final String CONNECTED_STREAM = "CONNECTED_STREAM";
-    public static final String DISCONNECTED_STREAM = "DISCONNECTED_STREAM";
-    public static final String EXTRA_USER = "user";
-    public static final String EXTRA_STREAM_TYPE = "type";
-
     private Context context;
     private AuthUserRecord userRecord;
     protected TwitterStream stream;
@@ -36,13 +32,13 @@ public abstract class Stream {
             @Override
             public void onConnect() {
                 Log.d("Stream", "Connect stream @" + Stream.this.userRecord.ScreenName);
-                Stream.this.context.sendBroadcast(createBroadcast(CONNECTED_STREAM));
+                Stream.this.context.sendBroadcast(createBroadcast(TwitterService.ACTION_STREAM_CONNECTED));
             }
 
             @Override
             public void onDisconnect() {
                 Log.d("Stream", "Disconnect stream @" + Stream.this.userRecord.ScreenName);
-                Stream.this.context.sendBroadcast(createBroadcast(DISCONNECTED_STREAM));
+                Stream.this.context.sendBroadcast(createBroadcast(TwitterService.ACTION_STREAM_CONNECTED));
             }
 
             @Override
@@ -54,8 +50,9 @@ public abstract class Stream {
 
     protected Intent createBroadcast(String action) {
         Intent intent = new Intent(action);
-        intent.putExtra(EXTRA_USER, userRecord);
-        intent.putExtra(EXTRA_STREAM_TYPE, getStreamType());
+        intent.putExtra(TwitterService.EXTRA_USER, userRecord);
+        intent.putExtra(TwitterService.EXTRA_CHANNEL_ID, getStreamType());
+        intent.putExtra(TwitterService.EXTRA_CHANNEL_NAME, getStreamType() + "Stream");
         return intent;
     }
 


### PR DESCRIPTION
#172 への対処をするにあたって、安定版のmastodon4jではStreaming中の通信切断がハンドルできず、強制終了する他ない状態でしたので、まずそちらに手を加えて私家版ビルドを作成しました。

https://github.com/shibafu528/mastodon4j/commit/5b315eb7bbec9b76849963ed522ab897dbce5d0c

このPRでは、y4aが参照するmastodon4jを通信切断ハンドル可能な私家版に変更し、通信切断時はリトライを行う処理を組み込みました。  
処理内容はTwitter4Jのものを参考にして、だんだんウェイト間隔を伸ばしながらリトライする方式を採っています。