### PR TITLE
ステータスの各実装にFav/RT(BT)可否判定のロジックを持たせる

### DIFF
--- a/Yukari/src/main/java/shibafu/yukari/entity/Status.kt
+++ b/Yukari/src/main/java/shibafu/yukari/entity/Status.kt
@@ -162,6 +162,16 @@ interface Status : Comparable<Status>, Serializable {
     }
 
     /**
+     * 指定したアカウントで、このステータスを再投稿できるか？
+     */
+    fun canRepost(userRecord: AuthUserRecord): Boolean = false
+
+    /**
+     * 指定したアカウントで、このステータスをお気に入りできるか？
+     */
+    fun canFavorite(userRecord: AuthUserRecord): Boolean = false
+
+    /**
      * 同じ内容を指す、より新しい別インスタンスの情報と比較してなるべく最新かつ情報の完全性が高いインスタンスを返す
      */
     fun merge(status: Status): Status {

--- a/Yukari/src/main/java/shibafu/yukari/mastodon/entity/DonStatus.kt
+++ b/Yukari/src/main/java/shibafu/yukari/mastodon/entity/DonStatus.kt
@@ -102,6 +102,16 @@ class DonStatus(val status: Status,
         return IStatus.RELATION_NONE
     }
 
+    override fun canRepost(userRecord: AuthUserRecord): Boolean {
+        val originStatus = if (isRepost) status.reblog!! else status
+        return userRecord.Provider.apiType == Provider.API_MASTODON &&
+                (originStatus.visibility == Status.Visibility.Public.value || originStatus.visibility == Status.Visibility.Unlisted.value)
+    }
+
+    override fun canFavorite(userRecord: AuthUserRecord): Boolean {
+        return userRecord.Provider.apiType == Provider.API_MASTODON
+    }
+
     override fun merge(status: IStatus): IStatus {
         super.merge(status)
 

--- a/Yukari/src/main/java/shibafu/yukari/twitter/entity/TwitterStatus.kt
+++ b/Yukari/src/main/java/shibafu/yukari/twitter/entity/TwitterStatus.kt
@@ -100,6 +100,15 @@ class TwitterStatus(val status: twitter4j.Status, override var representUser: Au
         return Status.RELATION_NONE
     }
 
+    override fun canRepost(userRecord: AuthUserRecord): Boolean {
+        return userRecord.Provider.apiType == Provider.API_TWITTER &&
+                (userRecord.ScreenName == originStatus.user.screenName || !originStatus.user.isProtected)
+    }
+
+    override fun canFavorite(userRecord: AuthUserRecord): Boolean {
+        return userRecord.Provider.apiType == Provider.API_TWITTER
+    }
+
     private val twitter4j.Status.originStatus: twitter4j.Status
         get() = if (this.isRetweet) this.retweetedStatus else this
 


### PR DESCRIPTION
refs #196 

既存のFav/RT(BT)可否判定はTwitterの仕様に依存していたため、Mastodonでは正しくない判定が行なわれていた。  
そこで、この可否判定の実装をStatusインターフェースを実装する各クラスに移動した。