### PR TITLE
Runtime Permission対応

### DIFF
--- a/Yukari/build.gradle
+++ b/Yukari/build.gradle
@@ -1,5 +1,6 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
+apply plugin: 'kotlin-kapt'
 
 repositories {
     mavenCentral()
@@ -192,14 +193,14 @@ dependencies {
 
     // Annotation Processor
     implementation 'com.jakewharton:butterknife:8.8.0'
-    annotationProcessor 'com.jakewharton:butterknife-compiler:8.8.0'
+    kapt 'com.jakewharton:butterknife-compiler:8.8.0'
     implementation "com.github.hotchemi:permissionsdispatcher:3.3.1", {
         exclude group: 'com.android.support', module: 'support-compat'
         exclude group: 'com.android.support', module: 'support-v13'
     }
-    annotationProcessor "com.github.hotchemi:permissionsdispatcher-processor:3.3.1"
+    kapt "com.github.hotchemi:permissionsdispatcher-processor:3.3.1"
     implementation project(':yukari-processor-runtime')
-    annotationProcessor project(':yukari-processor')
+    kapt project(':yukari-processor')
 
     // デバッグ用
     debugImplementation "com.squareup.leakcanary:leakcanary-android-no-op:$leakCanaryVersion"

--- a/Yukari/build.gradle
+++ b/Yukari/build.gradle
@@ -64,7 +64,7 @@ android {
     defaultConfig {
         applicationId "shibafu.yukari"
         minSdkVersion 16
-        targetSdkVersion 22
+        targetSdkVersion 23
         versionCode y4aVersionCode
         versionName y4aVersionName
 

--- a/Yukari/build.gradle
+++ b/Yukari/build.gradle
@@ -193,6 +193,11 @@ dependencies {
     // Annotation Processor
     implementation 'com.jakewharton:butterknife:8.8.0'
     annotationProcessor 'com.jakewharton:butterknife-compiler:8.8.0'
+    implementation "com.github.hotchemi:permissionsdispatcher:3.3.1", {
+        exclude group: 'com.android.support', module: 'support-compat'
+        exclude group: 'com.android.support', module: 'support-v13'
+    }
+    annotationProcessor "com.github.hotchemi:permissionsdispatcher-processor:3.3.1"
     implementation project(':yukari-processor-runtime')
     annotationProcessor project(':yukari-processor')
 

--- a/Yukari/src/main/assets/about.html
+++ b/Yukari/src/main/assets/about.html
@@ -46,6 +46,7 @@
     <li>LeakCanary</li>
     <li>Lightweight-Stream-API</li>
     <li>Open Sans</li>
+    <li>PermissionsDispatcher</li>
     <li>PreferenceFragment-Compat</li>
     <li>Twitter Intent</li>
     <li>twitter-text</li>


### PR DESCRIPTION
#142 の対応作業の第一歩として、targetSdkVersion を 23 に更新し、Runtime Permission への対応を実施しました。

実装方針は基本的に [PermissionsDispatcher](https://github.com/permissions-dispatcher/PermissionsDispatcher) を利用する形で、補助的に直接APIを使用した実装も行っています。
