### PR TITLE
Android 8.0対応 (Foreground Service, Notification Channels)

### DIFF
--- a/Yukari/build.gradle
+++ b/Yukari/build.gradle
@@ -65,7 +65,7 @@ android {
     defaultConfig {
         applicationId "shibafu.yukari"
         minSdkVersion 16
-        targetSdkVersion 25
+        targetSdkVersion 26
         versionCode y4aVersionCode
         versionName y4aVersionName
 

--- a/Yukari/src/main/java/shibafu/yukari/activity/AboutActivity.java
+++ b/Yukari/src/main/java/shibafu/yukari/activity/AboutActivity.java
@@ -116,6 +116,10 @@ public class AboutActivity extends ActionBarYukariBase {
 
     @Override
     public boolean onTouchEvent(MotionEvent event) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            return false;
+        }
+
         switch (event.getAction()) {
             case MotionEvent.ACTION_DOWN:
                 touching = true;

--- a/Yukari/src/main/java/shibafu/yukari/activity/CommandsPrefActivity.java
+++ b/Yukari/src/main/java/shibafu/yukari/activity/CommandsPrefActivity.java
@@ -1,11 +1,24 @@
 package shibafu.yukari.activity;
 
+import android.content.res.Resources;
+import android.media.MediaScannerConnection;
+import android.os.Build;
 import android.os.Bundle;
-
+import android.os.Environment;
+import android.preference.Preference;
+import android.support.annotation.RawRes;
+import android.widget.Toast;
 import com.github.machinarius.preferencefragment.PreferenceFragment;
-
 import shibafu.yukari.R;
 import shibafu.yukari.activity.base.ActionBarYukariBase;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Created by shibafu on 14/04/03.
@@ -28,10 +41,74 @@ public class CommandsPrefActivity extends ActionBarYukariBase {
     public void onServiceDisconnected() {}
 
     public static class InnerFragment extends PreferenceFragment {
+        private final File mediaDir = new File(Environment.getExternalStorageDirectory(), "Android/media/shibafu.yukari/Notifications");
+        private final Resource[] exportResources = {
+                new Resource(R.raw.y_reply, new File(mediaDir, "Yukari - Yukari Reply.ogg")),
+                new Resource(R.raw.y_fav, new File(mediaDir, "Yukari - Yukari Favorite.ogg")),
+                new Resource(R.raw.y_like, new File(mediaDir, "Yukari - Yukari Like.ogg")),
+                new Resource(R.raw.y_love, new File(mediaDir, "Yukari - Yukari Love.ogg")),
+                new Resource(R.raw.y_rt, new File(mediaDir, "Yukari - Yukari Retweet.ogg")),
+                new Resource(R.raw.akari_reply, new File(mediaDir, "Yukari - Akari Reply.ogg")),
+                new Resource(R.raw.akari_fav, new File(mediaDir, "Yukari - Akari Favorite.ogg")),
+                new Resource(R.raw.akari_like, new File(mediaDir, "Yukari - Akari Like.ogg")),
+                new Resource(R.raw.akari_love, new File(mediaDir, "Yukari - Akari Love.ogg")),
+                new Resource(R.raw.akari_retweet, new File(mediaDir, "Yukari - Akari Retweet.ogg")),
+                new Resource(R.raw.kiri_reply, new File(mediaDir, "Yukari - Kiri Reply.ogg")),
+                new Resource(R.raw.kiri_like, new File(mediaDir, "Yukari - Kiri Like.ogg")),
+                new Resource(R.raw.kiri_suki, new File(mediaDir, "Yukari - Kiri Love.ogg")),
+                new Resource(R.raw.kiri_retweet, new File(mediaDir, "Yukari - Kiri Retweet.ogg")),
+        };
+
         @Override
         public void onCreate(Bundle paramBundle) {
             super.onCreate(paramBundle);
             addPreferencesFromResource(R.xml.commands);
+
+            findPreference("pref_sound_theme").setEnabled(Build.VERSION.SDK_INT < Build.VERSION_CODES.O);
+
+            Preference prefSoundThemeExport = findPreference("pref_sound_theme_export");
+            prefSoundThemeExport.setEnabled(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O);
+            prefSoundThemeExport.setOnPreferenceClickListener(preference -> {
+                Resources res = getResources();
+
+                try {
+                    mediaDir.mkdirs();
+
+                    List<String> resourceAbsolutePaths = new ArrayList<>();
+                    for (Resource resource : exportResources) {
+                        try (InputStream input = res.openRawResource(resource.resId);
+                             OutputStream output = new FileOutputStream(resource.file)) {
+                            byte[] buf = new byte[4096];
+                            int length;
+                            while ((length = input.read(buf)) != -1) {
+                                output.write(buf, 0, length);
+                            }
+                        }
+
+                        resourceAbsolutePaths.add(resource.file.getAbsolutePath());
+                    }
+
+                    MediaScannerConnection.scanFile(getActivity(),
+                            resourceAbsolutePaths.toArray(new String[resourceAbsolutePaths.size()]),
+                            null, null);
+
+                    Toast.makeText(getActivity(), "エクスポートが完了しました。", Toast.LENGTH_SHORT).show();
+                } catch (IOException e) {
+                    e.printStackTrace();
+                    Toast.makeText(getActivity(), "エクスポート中にエラーが発生しました。", Toast.LENGTH_SHORT).show();
+                }
+                return true;
+            });
+        }
+
+        private static class Resource {
+            int resId;
+            File file;
+
+            Resource(@RawRes int resId, File file) {
+                this.resId = resId;
+                this.file = file;
+            }
         }
     }
 }

--- a/Yukari/src/main/java/shibafu/yukari/activity/ConfigActivity.java
+++ b/Yukari/src/main/java/shibafu/yukari/activity/ConfigActivity.java
@@ -56,7 +56,7 @@ public class ConfigActivity extends ActionBarYukariBase {
     @Override
     public void onServiceDisconnected() {}
 
-    public static class InnerFragment extends PreferenceFragment {
+    public static class InnerFragment extends PreferenceFragment implements SharedPreferences.OnSharedPreferenceChangeListener {
         public static InnerFragment newInstance(String category) {
             InnerFragment fragment = new InnerFragment();
             Bundle args = new Bundle();
@@ -209,6 +209,8 @@ public class ConfigActivity extends ActionBarYukariBase {
                             }
                             return true;
                         });
+
+                        findPreference("pref_notif_per_account_channel").setEnabled(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O);
                         break;
 
                     case "expert":
@@ -244,6 +246,28 @@ public class ConfigActivity extends ActionBarYukariBase {
                         findPreference("pref_exvoice_version").setSummary(summaryText);
                         break;
                     }
+                }
+            }
+        }
+
+        @Override
+        public void onPause() {
+            super.onPause();
+            getPreferenceScreen().getSharedPreferences().unregisterOnSharedPreferenceChangeListener(this);
+        }
+
+        @Override
+        public void onResume() {
+            super.onResume();
+            getPreferenceScreen().getSharedPreferences().registerOnSharedPreferenceChangeListener(this);
+        }
+
+        @Override
+        public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String key) {
+            if ("pref_notif_per_account_channel".equals(key)) {
+                TwitterService service = ((ConfigActivity) getActivity()).getTwitterService();
+                if (service != null) {
+                    service.reloadUsers();
                 }
             }
         }

--- a/Yukari/src/main/java/shibafu/yukari/activity/ConfigActivity.java
+++ b/Yukari/src/main/java/shibafu/yukari/activity/ConfigActivity.java
@@ -1,21 +1,27 @@
 package shibafu.yukari.activity;
 
 import android.app.AlertDialog;
+import android.app.NotificationManager;
+import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.os.Build;
 import android.os.Bundle;
+import android.preference.Preference;
 import android.preference.PreferenceManager;
 import android.support.annotation.Nullable;
 import android.text.TextUtils;
 import android.view.MenuItem;
 import android.view.View;
+import android.widget.Toast;
 import com.github.machinarius.preferencefragment.PreferenceFragment;
 import info.shibafu528.yukari.exvoice.BuildInfo;
 import shibafu.yukari.R;
 import shibafu.yukari.activity.base.ActionBarYukariBase;
+import shibafu.yukari.service.TwitterService;
+import shibafu.yukari.twitter.AuthUserRecord;
 
 /**
  * Created by Shibafu on 13/12/21.
@@ -188,6 +194,20 @@ public class ConfigActivity extends ActionBarYukariBase {
                         findPreference("pref_import").setOnPreferenceClickListener(preference -> {
                             startActivity(new Intent(getActivity(), BackupActivity.class).putExtra(BackupActivity.EXTRA_MODE, BackupActivity.EXTRA_MODE_IMPORT));
                             return false;
+                        });
+
+                        Preference prefRepairNotificationChannel = findPreference("pref_repair_notification_channel");
+                        prefRepairNotificationChannel.setEnabled(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O);
+                        prefRepairNotificationChannel.setOnPreferenceClickListener(preference -> {
+                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                                TwitterService service = ((ConfigActivity) getActivity()).getTwitterService();
+                                NotificationManager nm = (NotificationManager) getActivity().getSystemService(Context.NOTIFICATION_SERVICE);
+                                for (AuthUserRecord user : service.getUsers()) {
+                                    service.createAccountNotificationChannels(nm, user, true);
+                                }
+                                Toast.makeText(getActivity(), "修復しました。", Toast.LENGTH_SHORT).show();
+                            }
+                            return true;
                         });
                         break;
 

--- a/Yukari/src/main/java/shibafu/yukari/activity/ConfigActivity.java
+++ b/Yukari/src/main/java/shibafu/yukari/activity/ConfigActivity.java
@@ -2,6 +2,7 @@ package shibafu.yukari.activity;
 
 import android.app.AlertDialog;
 import android.app.NotificationManager;
+import android.content.ActivityNotFoundException;
 import android.content.Context;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -11,6 +12,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.preference.Preference;
 import android.preference.PreferenceManager;
+import android.provider.Settings;
 import android.support.annotation.Nullable;
 import android.text.TextUtils;
 import android.view.MenuItem;
@@ -181,6 +183,30 @@ public class ConfigActivity extends ActionBarYukariBase {
                                         selectedStates[which] = isChecked;
                                     });
                             builder.create().show();
+                            return true;
+                        });
+                        break;
+
+                    case "notify":
+                        Preference prefNotifSystemConfig = findPreference("pref_notif_system_config");
+                        prefNotifSystemConfig.setEnabled(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O);
+                        prefNotifSystemConfig.setOnPreferenceClickListener(preference -> {
+                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                                try {
+                                    // EMUI 8.xなど、正攻法で呼び出すと通知音のカスタマイズが行えない
+                                    // ベンダーオリジナルのActivityが起動されることがある。
+                                    // そういうのは嫌なので、素のAndroidの設定画面を指名して呼び出す。
+                                    Intent intent = new Intent(Settings.ACTION_CHANNEL_NOTIFICATION_SETTINGS);
+                                    intent.setClassName("com.android.settings", "com.android.settings.Settings$AppNotificationSettingsActivity");
+                                    intent.putExtra(Settings.EXTRA_APP_PACKAGE, getContext().getPackageName());
+                                    startActivity(intent);
+                                } catch (ActivityNotFoundException e) {
+                                    // このブロックをわざわざ用意する意味はないかもしれない、とりあえず正攻法での呼出を書いただけ
+                                    Intent intent = new Intent(Settings.ACTION_CHANNEL_NOTIFICATION_SETTINGS);
+                                    intent.putExtra(Settings.EXTRA_APP_PACKAGE, getContext().getPackageName());
+                                    startActivity(intent);
+                                }
+                            }
                             return true;
                         });
                         break;

--- a/Yukari/src/main/java/shibafu/yukari/activity/IntentActivity.java
+++ b/Yukari/src/main/java/shibafu/yukari/activity/IntentActivity.java
@@ -4,6 +4,7 @@ import android.app.ProgressDialog;
 import android.content.Intent;
 import android.os.Bundle;
 import android.preference.PreferenceManager;
+import android.support.v4.content.ContextCompat;
 import android.util.Pair;
 import android.view.Window;
 import android.widget.Toast;
@@ -73,7 +74,7 @@ public class IntentActivity extends ActionBarYukariBase {
                             StatusDraft draft = new StatusDraft();
                             draft.setWriters(activity.twitterUser.toSingleList());
                             draft.setText("＼ﾕｯｶﾘｰﾝ／");
-                            activity.startService(PostService.newIntent(activity, draft));
+                            ContextCompat.startForegroundService(activity, PostService.newIntent(activity, draft));
                             break;
                         default:
                             Toast.makeText(activity, "非対応タグです", Toast.LENGTH_SHORT).show();

--- a/Yukari/src/main/java/shibafu/yukari/activity/MainActivity.java
+++ b/Yukari/src/main/java/shibafu/yukari/activity/MainActivity.java
@@ -14,6 +14,7 @@ import android.support.annotation.NonNull;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentManager;
 import android.support.v4.app.FragmentStatePagerAdapter;
+import android.support.v4.content.ContextCompat;
 import android.support.v4.util.ArrayMap;
 import android.support.v4.util.LongSparseArray;
 import android.support.v4.view.ViewPager;
@@ -152,7 +153,7 @@ public class MainActivity extends ActionBarYukariBase implements SearchDialogFra
 
         //サービスの常駐
         if (sharedPreferences.getBoolean("pref_enable_service", false)) {
-            startService(new Intent(getApplicationContext(), TwitterService.class));
+            ContextCompat.startForegroundService(this, new Intent(getApplicationContext(), TwitterService.class));
         }
     }
 

--- a/Yukari/src/main/java/shibafu/yukari/activity/TweetActivity.java
+++ b/Yukari/src/main/java/shibafu/yukari/activity/TweetActivity.java
@@ -1080,7 +1080,7 @@ public class TweetActivity extends ActionBarYukariBase implements DraftDialogFra
         } else {
             //サービスに投げる
             Intent intent = PostService.newIntent(TweetActivity.this, draft);
-            startService(intent);
+            ContextCompat.startForegroundService(this, intent);
 
             if (sp.getBoolean("first_guide", true)) {
                 sp.edit().putBoolean("first_guide", false).commit();

--- a/Yukari/src/main/java/shibafu/yukari/common/NotificationChannelPrefix.java
+++ b/Yukari/src/main/java/shibafu/yukari/common/NotificationChannelPrefix.java
@@ -1,0 +1,10 @@
+package shibafu.yukari.common;
+
+public final class NotificationChannelPrefix {
+    public static final String GROUP_ACCOUNT = "account::";
+    public static final String CHANNEL_MENTION = "mention::";
+    public static final String CHANNEL_REPOST = "repost::";
+    public static final String CHANNEL_FAVORITE = "favorite::";
+    public static final String CHANNEL_MESSAGE = "message::";
+    public static final String CHANNEL_REPOST_RESPOND = "repost_respond::";
+}

--- a/Yukari/src/main/java/shibafu/yukari/common/NotificationPreference.java
+++ b/Yukari/src/main/java/shibafu/yukari/common/NotificationPreference.java
@@ -2,6 +2,7 @@ package shibafu.yukari.common;
 
 import android.content.Context;
 import android.content.res.TypedArray;
+import android.os.Build;
 import android.preference.DialogPreference;
 import android.util.AttributeSet;
 import android.view.LayoutInflater;
@@ -9,6 +10,7 @@ import android.view.View;
 import android.widget.CheckBox;
 import android.widget.RadioButton;
 import android.widget.RadioGroup;
+import android.widget.TextView;
 import shibafu.yukari.R;
 
 /**
@@ -61,6 +63,10 @@ public class NotificationPreference extends DialogPreference{
         }
         else {
             ((RadioButton)notificationTypeGroup.findViewById(R.id.rbNotifToast)).setChecked(true);
+        }
+        TextView tvOreoNotice = view.findViewById(R.id.tvNotifOreoNotice);
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            tvOreoNotice.setVisibility(View.GONE);
         }
         return view;
     }

--- a/Yukari/src/main/java/shibafu/yukari/core/YukariApplication.java
+++ b/Yukari/src/main/java/shibafu/yukari/core/YukariApplication.java
@@ -2,16 +2,26 @@ package shibafu.yukari.core;
 
 import android.app.Application;
 import android.app.NotificationChannel;
+import android.app.NotificationChannelGroup;
 import android.app.NotificationManager;
 import android.content.Context;
+import android.media.AudioAttributes;
+import android.media.AudioManager;
+import android.net.Uri;
 import android.os.Build;
 import android.preference.PreferenceManager;
+import android.support.annotation.NonNull;
+import android.support.annotation.RequiresApi;
 import com.google.android.gms.common.GooglePlayServicesNotAvailableException;
 import com.google.android.gms.common.GooglePlayServicesRepairableException;
 import com.google.android.gms.security.ProviderInstaller;
 import com.squareup.leakcanary.LeakCanary;
 import shibafu.yukari.R;
+import shibafu.yukari.common.NotificationChannelPrefix;
 import twitter4j.AlternativeHttpClientImpl;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Created by shibafu on 2015/08/29.
@@ -63,6 +73,8 @@ public class YukariApplication extends Application {
                     "バックグラウンド処理",
                     NotificationManager.IMPORTANCE_LOW);
             nm.createNotificationChannel(asyncActionChannel);
+
+            createAllAccountNotificationChannels(nm);
         }
 
         if (LeakCanary.isInAnalyzerProcess(this)) {
@@ -75,5 +87,56 @@ public class YukariApplication extends Application {
     protected void attachBaseContext(Context base) {
         super.attachBaseContext(base);
 //        MultiDex.install(this);
+    }
+
+    /**
+     * すべてのアカウント向けの共通通知チャンネルを生成します。
+     * @param nm NotificationManager
+     */
+    @RequiresApi(Build.VERSION_CODES.O)
+    private void createAllAccountNotificationChannels(@NonNull NotificationManager nm) {
+        List<NotificationChannel> channels = new ArrayList<>();
+        final AudioAttributes audioAttributes = new AudioAttributes.Builder().setLegacyStreamType(AudioManager.STREAM_NOTIFICATION).build();
+        final String groupId = NotificationChannelPrefix.GROUP_ACCOUNT + "all";
+
+        NotificationChannelGroup group = new NotificationChannelGroup(groupId, "すべてのアカウント");
+        nm.createNotificationChannelGroup(group);
+
+        // Mention
+        NotificationChannel mentionChannel = new NotificationChannel(NotificationChannelPrefix.CHANNEL_MENTION + "all", "メンション通知", NotificationManager.IMPORTANCE_HIGH);
+        mentionChannel.setGroup(groupId);
+        mentionChannel.setSound(Uri.parse("android.resource://shibafu.yukari/raw/se_reply"), audioAttributes);
+        mentionChannel.setDescription("@付き投稿の通知\n注意: ここで有効にしていても、アプリ内の通知設定を有効にしていないと機能しません！");
+        channels.add(mentionChannel);
+
+        // Repost (RT, Boost)
+        NotificationChannel repostChannel = new NotificationChannel(NotificationChannelPrefix.CHANNEL_REPOST + "all", "リツイート・ブースト通知", NotificationManager.IMPORTANCE_HIGH);
+        repostChannel.setGroup(groupId);
+        repostChannel.setSound(Uri.parse("android.resource://shibafu.yukari/raw/se_rt"), audioAttributes);
+        repostChannel.setDescription("あなたの投稿がリツイート・ブーストされた時の通知\n注意: ここで有効にしていても、アプリ内の通知設定を有効にしていないと機能しません！");
+        channels.add(repostChannel);
+
+        // Favorite
+        NotificationChannel favoriteChannel = new NotificationChannel(NotificationChannelPrefix.CHANNEL_FAVORITE + "all", "お気に入り通知", NotificationManager.IMPORTANCE_HIGH);
+        favoriteChannel.setGroup(groupId);
+        favoriteChannel.setSound(Uri.parse("android.resource://shibafu.yukari/raw/se_fav"), audioAttributes);
+        favoriteChannel.setDescription("あなたの投稿がお気に入り登録された時の通知\n注意: ここで有効にしていても、アプリ内の通知設定を有効にしていないと機能しません！");
+        channels.add(favoriteChannel);
+
+        // Message
+        NotificationChannel messageChannel = new NotificationChannel(NotificationChannelPrefix.CHANNEL_MESSAGE + "all", "メッセージ通知", NotificationManager.IMPORTANCE_HIGH);
+        messageChannel.setGroup(groupId);
+        messageChannel.setSound(Uri.parse("android.resource://shibafu.yukari/raw/se_reply"), audioAttributes);
+        messageChannel.setDescription("あなた宛のメッセージを受信した時の通知\n注意: ここで有効にしていても、アプリ内の通知設定を有効にしていないと機能しません！");
+        channels.add(messageChannel);
+
+        // Repost Respond (RT-Respond)
+        NotificationChannel repostRespondChannel = new NotificationChannel(NotificationChannelPrefix.CHANNEL_REPOST_RESPOND + "all", "RTレスポンス通知", NotificationManager.IMPORTANCE_HIGH);
+        repostRespondChannel.setGroup(groupId);
+        repostRespondChannel.setSound(Uri.parse("android.resource://shibafu.yukari/raw/se_reply"), audioAttributes);
+        repostRespondChannel.setDescription("あなたの投稿がリツイート・ブーストされ、その直後に感想文らしき投稿を発見した時の通知\n注意: ここで有効にしていても、アプリ内の通知設定を有効にしていないと機能しません！");
+        channels.add(repostRespondChannel);
+
+        nm.createNotificationChannels(channels);
     }
 }

--- a/Yukari/src/main/java/shibafu/yukari/core/YukariApplication.java
+++ b/Yukari/src/main/java/shibafu/yukari/core/YukariApplication.java
@@ -1,12 +1,16 @@
 package shibafu.yukari.core;
 
 import android.app.Application;
+import android.app.NotificationChannel;
+import android.app.NotificationManager;
 import android.content.Context;
+import android.os.Build;
 import android.preference.PreferenceManager;
 import com.google.android.gms.common.GooglePlayServicesNotAvailableException;
 import com.google.android.gms.common.GooglePlayServicesRepairableException;
 import com.google.android.gms.security.ProviderInstaller;
 import com.squareup.leakcanary.LeakCanary;
+import shibafu.yukari.R;
 import twitter4j.AlternativeHttpClientImpl;
 
 /**
@@ -30,6 +34,35 @@ public class YukariApplication extends Application {
         if (PreferenceManager.getDefaultSharedPreferences(this).getBoolean("pref_force_http1", false)) {
             AlternativeHttpClientImpl.sPreferHttp2 = false;
             AlternativeHttpClientImpl.sPreferSpdy = false;
+        }
+
+        // 通知チャンネルの作成
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            NotificationManager nm = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+
+            NotificationChannel generalChannel = new NotificationChannel(
+                    getString(R.string.notification_channel_id_general),
+                    "その他の通知",
+                    NotificationManager.IMPORTANCE_DEFAULT);
+            nm.createNotificationChannel(generalChannel);
+
+            NotificationChannel errorChannel = new NotificationChannel(
+                    getString(R.string.notification_channel_id_error),
+                    "エラーの通知",
+                    NotificationManager.IMPORTANCE_DEFAULT);
+            nm.createNotificationChannel(errorChannel);
+
+            NotificationChannel coreServiceChannel = new NotificationChannel(
+                    getString(R.string.notification_channel_id_core_service),
+                    "常駐サービス",
+                    NotificationManager.IMPORTANCE_MIN);
+            nm.createNotificationChannel(coreServiceChannel);
+
+            NotificationChannel asyncActionChannel = new NotificationChannel(
+                    getString(R.string.notification_channel_id_async_action),
+                    "バックグラウンド処理",
+                    NotificationManager.IMPORTANCE_LOW);
+            nm.createNotificationChannel(asyncActionChannel);
         }
 
         if (LeakCanary.isInAnalyzerProcess(this)) {

--- a/Yukari/src/main/java/shibafu/yukari/fragment/QuickPostFragment.kt
+++ b/Yukari/src/main/java/shibafu/yukari/fragment/QuickPostFragment.kt
@@ -5,6 +5,7 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.support.v4.app.Fragment
+import android.support.v4.content.ContextCompat
 import android.text.Editable
 import android.text.Spanned
 import android.text.TextWatcher
@@ -163,7 +164,7 @@ class QuickPostFragment : Fragment() {
             )
 
             //サービス起動
-            activity?.startService(PostService.newIntent(context.applicationContext, draft))
+            ContextCompat.startForegroundService(activity, PostService.newIntent(context.applicationContext, draft))
 
             //投稿欄を掃除する
             etTweet.setText("")

--- a/Yukari/src/main/java/shibafu/yukari/fragment/status/StatusMainFragment.kt
+++ b/Yukari/src/main/java/shibafu/yukari/fragment/status/StatusMainFragment.kt
@@ -6,6 +6,8 @@ import android.app.Activity
 import android.content.DialogInterface
 import android.content.Intent
 import android.os.Bundle
+import android.support.v4.app.NotificationCompat
+import android.support.v4.content.ContextCompat
 import android.support.v7.widget.PopupMenu
 import android.view.Gravity
 import android.view.LayoutInflater
@@ -323,17 +325,19 @@ class StatusMainFragment : TwitterFragment(), StatusChildUI, SimpleAlertDialogFr
                 REQUEST_RT_QUOTE -> {
                     val draft = data?.getParcelableExtra(TweetActivity.EXTRA_DRAFT) as? StatusDraft ?: return
                     //これ、RT失敗してもツイートしちゃうんですよねえ
-                    activity.startService(PostService.newIntent(activity, draft,
-                            PostService.FLAG_RETWEET,
-                            status))
+                    ContextCompat.startForegroundService(activity,
+                            PostService.newIntent(activity, draft,
+                                    PostService.FLAG_RETWEET,
+                                    status))
                     activity.finish()
                 }
                 REQUEST_FRT_QUOTE -> {
                     val draft = data?.getParcelableExtra(TweetActivity.EXTRA_DRAFT) as? StatusDraft ?: return
                     //これ、RT失敗してもツイートしちゃうんですよねえ
-                    activity.startService(PostService.newIntent(activity, draft,
-                            PostService.FLAG_RETWEET or PostService.FLAG_FAVORITE,
-                            status))
+                    ContextCompat.startForegroundService(activity,
+                            PostService.newIntent(activity, draft,
+                                    PostService.FLAG_RETWEET or PostService.FLAG_FAVORITE,
+                                    status))
                     activity.finish()
                 }
                 REQUEST_MULTI_FAVORITE -> {

--- a/Yukari/src/main/java/shibafu/yukari/linkage/StatusNotifier.java
+++ b/Yukari/src/main/java/shibafu/yukari/linkage/StatusNotifier.java
@@ -198,12 +198,14 @@ public class StatusNotifier implements Releasable {
             Uri sound = getNotificationUrl(category);
             String titleHeader = "", tickerHeader = "";
             long[] pattern = null;
+            String channelId;
             switch (category) {
                 case R.integer.notification_replied:
                     icon = R.drawable.ic_stat_reply;
                     titleHeader = "Reply from @";
                     tickerHeader = "リプライ : @";
                     pattern = VIB_REPLY;
+                    channelId = "mention::" + status.getRepresentUser().Url;
                     break;
                 case R.integer.notification_retweeted:
                     icon = R.drawable.ic_stat_retweet;
@@ -211,6 +213,7 @@ public class StatusNotifier implements Releasable {
                     tickerHeader = "RTされました : @";
                     pattern = VIB_RETWEET;
                     color = Color.rgb(0, 128, 0);
+                    channelId = "repost::" + status.getRepresentUser().Url;
                     break;
                 case R.integer.notification_faved:
                     icon = R.drawable.ic_stat_favorite;
@@ -218,22 +221,27 @@ public class StatusNotifier implements Releasable {
                     tickerHeader = "ふぁぼられ : @";
                     pattern = VIB_FAVED;
                     color = Color.rgb(255, 128, 0);
+                    channelId = "favorite::" + status.getRepresentUser().Url;
                     break;
                 case R.integer.notification_message:
                     icon = R.drawable.ic_stat_message;
                     titleHeader = "Message from @";
                     tickerHeader = "DM : @";
                     pattern = VIB_REPLY;
+                    channelId = "message::" + status.getRepresentUser().Url;
                     break;
                 case R.integer.notification_respond:
                     icon = R.drawable.ic_stat_reply;
                     titleHeader = "RT-Respond from @";
                     tickerHeader = "RTレスポンス : @";
                     pattern = VIB_REPLY;
+                    channelId = "repost_respond::" + status.getRepresentUser().Url;
                     break;
+                default:
+                    throw new IllegalArgumentException("Undefined notification category " + category);
             }
             if (notificationType.getNotificationType() == NotificationType.TYPE_NOTIF) {
-                NotificationCompat.Builder builder = new NotificationCompat.Builder(context.getApplicationContext());
+                NotificationCompat.Builder builder = new NotificationCompat.Builder(context.getApplicationContext(), channelId);
                 builder.setSmallIcon(icon);
                 builder.setContentTitle(titleHeader + actionBy.getScreenName());
                 builder.setContentText(status.getUser().getScreenName() + ": " + status.getText());

--- a/Yukari/src/main/java/shibafu/yukari/linkage/StatusNotifier.java
+++ b/Yukari/src/main/java/shibafu/yukari/linkage/StatusNotifier.java
@@ -22,6 +22,7 @@ import info.shibafu528.yukari.processor.autorelease.AutoReleaser;
 import shibafu.yukari.R;
 import shibafu.yukari.activity.MainActivity;
 import shibafu.yukari.activity.TweetActivity;
+import shibafu.yukari.common.NotificationChannelPrefix;
 import shibafu.yukari.common.NotificationType;
 import shibafu.yukari.common.TabType;
 import shibafu.yukari.entity.Status;
@@ -205,7 +206,7 @@ public class StatusNotifier implements Releasable {
                     titleHeader = "Reply from @";
                     tickerHeader = "リプライ : @";
                     pattern = VIB_REPLY;
-                    channelId = "mention::" + status.getRepresentUser().Url;
+                    channelId = NotificationChannelPrefix.CHANNEL_MENTION + status.getRepresentUser().Url;
                     break;
                 case R.integer.notification_retweeted:
                     icon = R.drawable.ic_stat_retweet;
@@ -213,7 +214,7 @@ public class StatusNotifier implements Releasable {
                     tickerHeader = "RTされました : @";
                     pattern = VIB_RETWEET;
                     color = Color.rgb(0, 128, 0);
-                    channelId = "repost::" + status.getRepresentUser().Url;
+                    channelId = NotificationChannelPrefix.CHANNEL_REPOST + status.getRepresentUser().Url;
                     break;
                 case R.integer.notification_faved:
                     icon = R.drawable.ic_stat_favorite;
@@ -221,21 +222,21 @@ public class StatusNotifier implements Releasable {
                     tickerHeader = "ふぁぼられ : @";
                     pattern = VIB_FAVED;
                     color = Color.rgb(255, 128, 0);
-                    channelId = "favorite::" + status.getRepresentUser().Url;
+                    channelId = NotificationChannelPrefix.CHANNEL_FAVORITE + status.getRepresentUser().Url;
                     break;
                 case R.integer.notification_message:
                     icon = R.drawable.ic_stat_message;
                     titleHeader = "Message from @";
                     tickerHeader = "DM : @";
                     pattern = VIB_REPLY;
-                    channelId = "message::" + status.getRepresentUser().Url;
+                    channelId = NotificationChannelPrefix.CHANNEL_MESSAGE + status.getRepresentUser().Url;
                     break;
                 case R.integer.notification_respond:
                     icon = R.drawable.ic_stat_reply;
                     titleHeader = "RT-Respond from @";
                     tickerHeader = "RTレスポンス : @";
                     pattern = VIB_REPLY;
-                    channelId = "repost_respond::" + status.getRepresentUser().Url;
+                    channelId = NotificationChannelPrefix.CHANNEL_REPOST_RESPOND + status.getRepresentUser().Url;
                     break;
                 default:
                     throw new IllegalArgumentException("Undefined notification category " + category);

--- a/Yukari/src/main/java/shibafu/yukari/linkage/StatusNotifier.java
+++ b/Yukari/src/main/java/shibafu/yukari/linkage/StatusNotifier.java
@@ -200,13 +200,19 @@ public class StatusNotifier implements Releasable {
             String titleHeader = "", tickerHeader = "";
             long[] pattern = null;
             String channelId;
+            String channelIdSuffix;
+            if (sharedPreferences.getBoolean("pref_notif_per_account_channel", false)) {
+                channelIdSuffix = status.getRepresentUser().Url;
+            } else {
+                channelIdSuffix = "all";
+            }
             switch (category) {
                 case R.integer.notification_replied:
                     icon = R.drawable.ic_stat_reply;
                     titleHeader = "Reply from @";
                     tickerHeader = "リプライ : @";
                     pattern = VIB_REPLY;
-                    channelId = NotificationChannelPrefix.CHANNEL_MENTION + status.getRepresentUser().Url;
+                    channelId = NotificationChannelPrefix.CHANNEL_MENTION + channelIdSuffix;
                     break;
                 case R.integer.notification_retweeted:
                     icon = R.drawable.ic_stat_retweet;
@@ -214,7 +220,7 @@ public class StatusNotifier implements Releasable {
                     tickerHeader = "RTされました : @";
                     pattern = VIB_RETWEET;
                     color = Color.rgb(0, 128, 0);
-                    channelId = NotificationChannelPrefix.CHANNEL_REPOST + status.getRepresentUser().Url;
+                    channelId = NotificationChannelPrefix.CHANNEL_REPOST + channelIdSuffix;
                     break;
                 case R.integer.notification_faved:
                     icon = R.drawable.ic_stat_favorite;
@@ -222,21 +228,21 @@ public class StatusNotifier implements Releasable {
                     tickerHeader = "ふぁぼられ : @";
                     pattern = VIB_FAVED;
                     color = Color.rgb(255, 128, 0);
-                    channelId = NotificationChannelPrefix.CHANNEL_FAVORITE + status.getRepresentUser().Url;
+                    channelId = NotificationChannelPrefix.CHANNEL_FAVORITE + channelIdSuffix;
                     break;
                 case R.integer.notification_message:
                     icon = R.drawable.ic_stat_message;
                     titleHeader = "Message from @";
                     tickerHeader = "DM : @";
                     pattern = VIB_REPLY;
-                    channelId = NotificationChannelPrefix.CHANNEL_MESSAGE + status.getRepresentUser().Url;
+                    channelId = NotificationChannelPrefix.CHANNEL_MESSAGE + channelIdSuffix;
                     break;
                 case R.integer.notification_respond:
                     icon = R.drawable.ic_stat_reply;
                     titleHeader = "RT-Respond from @";
                     tickerHeader = "RTレスポンス : @";
                     pattern = VIB_REPLY;
-                    channelId = NotificationChannelPrefix.CHANNEL_REPOST_RESPOND + status.getRepresentUser().Url;
+                    channelId = NotificationChannelPrefix.CHANNEL_REPOST_RESPOND + channelIdSuffix;
                     break;
                 default:
                     throw new IllegalArgumentException("Undefined notification category " + category);

--- a/Yukari/src/main/java/shibafu/yukari/service/PostService.java
+++ b/Yukari/src/main/java/shibafu/yukari/service/PostService.java
@@ -97,7 +97,7 @@ public class PostService extends IntentService{
             return;
         }
 
-        NotificationCompat.Builder builder = new NotificationCompat.Builder(getApplicationContext())
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(getApplicationContext(), getString(R.string.notification_channel_id_async_action))
                 .setTicker("ツイートを送信中")
                 .setContentTitle("ツイートを送信中")
                 .setContentText(draft.getText())
@@ -318,7 +318,7 @@ public class PostService extends IntentService{
     }
 
     private void showErrorMessage(int id, StatusDraft draft, String reason) {
-        NotificationCompat.Builder builder = new NotificationCompat.Builder(getApplicationContext())
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(getApplicationContext(), getString(R.string.notification_channel_id_error))
                 .setTicker("ツイートに失敗しました")
                 .setContentTitle("ツイートに失敗しました")
                 .setContentText(reason)

--- a/Yukari/src/main/java/shibafu/yukari/service/TwitterService.java
+++ b/Yukari/src/main/java/shibafu/yukari/service/TwitterService.java
@@ -177,7 +177,7 @@ public class TwitterService extends Service{
 
     @Override
     public int onStartCommand(Intent intent, int flags, int startId) {
-        NotificationCompat.Builder builder = new NotificationCompat.Builder(getApplicationContext())
+        NotificationCompat.Builder builder = new NotificationCompat.Builder(getApplicationContext(), getString(R.string.notification_channel_id_core_service))
                 .setLargeIcon(BitmapFactory.decodeResource(getResources(), R.drawable.ic_launcher))
                 .setSmallIcon(android.R.drawable.stat_notify_sync_noanim)
                 .setContentTitle(getString(R.string.app_name))
@@ -302,7 +302,7 @@ public class TwitterService extends Service{
                     String versionString = getLatestMikutterVersion("stable");
                     if (versionString != null) {
                         Log.d("mikutter-version", versionString);
-                        NotificationCompat.Builder builder = new NotificationCompat.Builder(getApplicationContext())
+                        NotificationCompat.Builder builder = new NotificationCompat.Builder(getApplicationContext(), getString(R.string.notification_channel_id_general))
                                 .setSmallIcon(R.drawable.ic_stat_favorite)
                                 .setContentTitle("mikutter " + versionString)
                                 .setContentText("mikutter " + versionString + " がリリースされています。")

--- a/Yukari/src/main/res/layout/dialog_pref_notif.xml
+++ b/Yukari/src/main/res/layout/dialog_pref_notif.xml
@@ -78,4 +78,14 @@
             android:id="@+id/rbNotifToast" />
     </RadioGroup>
 
+    <TextView
+        android:id="@+id/tvNotifOreoNotice"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginLeft="8dp"
+        android:layout_marginRight="8dp"
+        android:layout_marginTop="8dp"
+        android:textAppearance="?android:textAppearanceSmall"
+        android:text="Android 8.0以上の端末でステータス通知を使う場合、ここでサウンドとバイブレーションの設定をしても無視されます。\n「システムの通知設定を開く」から設定してください。"/>
+
 </LinearLayout>

--- a/Yukari/src/main/res/values/strings.xml
+++ b/Yukari/src/main/res/values/strings.xml
@@ -61,4 +61,9 @@
 
     <string name="error_storage_not_found">[Yukari 起動エラー] ストレージエラー\nアプリの動作にはストレージが必須です\nSDカードが挿入されているか確認してください</string>
     <string name="error_broken_font">[Yukari データチェック]\nフォントファイルが壊れています\n再展開を行います</string>
+
+    <string name="notification_channel_id_general">General</string>
+    <string name="notification_channel_id_error">Error</string>
+    <string name="notification_channel_id_core_service">CoreService</string>
+    <string name="notification_channel_id_async_action">AsyncAction</string>
 </resources>

--- a/Yukari/src/main/res/xml/commands.xml
+++ b/Yukari/src/main/res/xml/commands.xml
@@ -92,10 +92,14 @@
         <ListPreference
             android:key="pref_sound_theme"
             android:title="サウンドテーマ"
-            android:summary="通知音のテーマを設定します\n事前にAbout画面を連打して、ボイスモードを有効にしてください"
+            android:summary="通知音のテーマを設定します\n事前にAbout画面を連打して、ボイスモードを有効にしてください\n(※ Android 7.1以下のみ有効)"
             android:defaultValue="yukari_fav"
             android:entries="@array/pref_sound_theme_entries"
             android:entryValues="@array/pref_sound_theme_values"/>
+        <Preference
+            android:key="pref_sound_theme_export"
+            android:title="サウンドテーマをエクスポート"
+            android:summary="システムの通知設定で使える通知音をストレージにエクスポートします。\n(※ Android 8.0以上のみ有効)"/>
         <CheckBoxPreference
             android:key="j_yukari_joke_voices"
             android:title="ゆかりさんをいじる"

--- a/Yukari/src/main/res/xml/pref_expert.xml
+++ b/Yukari/src/main/res/xml/pref_expert.xml
@@ -40,6 +40,10 @@
                 android:targetPackage="@string/applicationId"
                 android:targetClass="shibafu.yukari.activity.BookmarkRepairActivity"/>
         </Preference>
+        <Preference
+            android:key="pref_repair_notification_channel"
+            android:title="通知チャンネルの修復"
+            android:summary="システムの通知設定の項目を修復します。システム設定で通知音をカスタマイズしている場合、その情報は失われます。\n(※Android 8.0以上のみ有効)"/>
         <CheckBoxPreference
             android:key="pref_show_menubutton"
             android:title="メニューボタンを表示"

--- a/Yukari/src/main/res/xml/pref_notify.xml
+++ b/Yukari/src/main/res/xml/pref_notify.xml
@@ -30,4 +30,8 @@
         android:title="ストリーミング通信状態通知"
         android:summary="ストリーミングに接続・切断された時にメッセージを表示します"
         android:defaultValue="true"/>
+    <Preference
+        android:key="pref_notif_system_config"
+        android:title="システムの通知設定を開く"
+        android:summary="Android 8.0以降ではシステムの通知設定からカスタマイズできます。"/>
 </PreferenceScreen>

--- a/Yukari/src/main/res/xml/pref_notify.xml
+++ b/Yukari/src/main/res/xml/pref_notify.xml
@@ -34,4 +34,8 @@
         android:key="pref_notif_system_config"
         android:title="システムの通知設定を開く"
         android:summary="Android 8.0以降ではシステムの通知設定からカスタマイズできます。"/>
+    <CheckBoxPreference
+        android:key="pref_notif_per_account_channel"
+        android:title="アカウント別の通知設定を使う"
+        android:summary="システムの通知設定の項目を、アカウント別に分割します。\nアカウントごとに細かな設定を行えるようになります。\n(※Android 8.0以上のみ有効)"/>
 </PreferenceScreen>


### PR DESCRIPTION
refs #142

## 対応事項
* [x] Foreground Serviceの起動方式変更
* [x] 一般通知/Foreground Service通知のチャンネル対応
* [x] アカウントレベルの通知のチャンネル対応 (Favとか)

## TODO
* アカウントレベルの通知チャンネルはどの粒度で切るか？
  * アカウントごとに1つにするか
  * アカウントごとにMention, Fav, RT, Message, RT-Respondをそれぞれ作るか
    * こちらで決定。ただしアカウント数が多いと設定が手間なので、そんなに設定する気がない人向けに一括設定に近いチャンネルを用意。
* アカウントレベルの通知チャンネルを作成・削除するタイミングを決める
  * 作成はアカウントリロードした時
  * 削除はアカウント削除操作した時
  * バックアップインポートの時どうなるかを考慮すること