### PR TITLE
アプリ内プレビュー不能な動画などのリンクを開くことができなくなっていたバグの修正

### DIFF
--- a/Yukari/src/main/java/shibafu/yukari/fragment/status/StatusLinkFragment.kt
+++ b/Yukari/src/main/java/shibafu/yukari/fragment/status/StatusLinkFragment.kt
@@ -212,9 +212,15 @@ class StatusLinkFragment : ListTwitterFragment(), StatusChildUI {
         override val label: String = media.browseUrl
 
         override fun onClick() {
-            val intent = Intent(Intent.ACTION_VIEW, Uri.parse(media.browseUrl), activity, PreviewActivity::class.java)
-            intent.putExtra(PreviewActivity.EXTRA_STATUS, status)
-            startActivity(intent)
+            if (media.canPreview()) {
+                val intent = Intent(Intent.ACTION_VIEW, Uri.parse(media.browseUrl), activity, PreviewActivity::class.java)
+                intent.putExtra(PreviewActivity.EXTRA_STATUS, status)
+                startActivity(intent)
+            } else {
+                val intent = Intent(Intent.ACTION_VIEW, Uri.parse(media.browseUrl))
+                intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+                startActivity(intent)
+            }
         }
 
         override fun onLongClick(): Boolean {


### PR DESCRIPTION
StatusLinkFragmentをKotlin化した際に、存在を忘れていて判定入れ忘れてたみたいです……。

ニコ動などの動画系サイトは基本的にサムネ表示だけしてプレビュー不能、みたいにしてたはずなのでその辺が影響対象。