### PR TITLE
Mastodonの添付動画のサムネイルだけは表示できるようにした

### DIFF
--- a/Yukari/src/main/java/shibafu/yukari/mastodon/entity/DonStatus.kt
+++ b/Yukari/src/main/java/shibafu/yukari/mastodon/entity/DonStatus.kt
@@ -16,6 +16,7 @@ import shibafu.yukari.mastodon.MastodonUtil
 import shibafu.yukari.media2.Media
 import shibafu.yukari.media2.MediaFactory
 import shibafu.yukari.media2.impl.DonPicture
+import shibafu.yukari.media2.impl.DonVideo
 import shibafu.yukari.twitter.AuthUserRecord
 import shibafu.yukari.util.MorseCodec
 import java.io.StringReader
@@ -133,9 +134,9 @@ class DonStatus(val status: Status,
             val links = LinkedHashSet<String>()
 
             status.mediaAttachments.forEach { attachment ->
-                // TODO: videoとかgifvとかは...?
                 when (attachment.type) {
                     "image" -> media += DonPicture(attachment)
+                    "video", "gifv" -> media += DonVideo(attachment)
                     else -> links += attachment.remoteUrl ?: attachment.url
                 }
             }

--- a/Yukari/src/main/java/shibafu/yukari/media2/impl/DonVideo.kt
+++ b/Yukari/src/main/java/shibafu/yukari/media2/impl/DonVideo.kt
@@ -1,0 +1,13 @@
+package shibafu.yukari.media2.impl
+
+import com.sys1yagi.mastodon4j.api.entity.Attachment
+import shibafu.yukari.media2.MemoizeMedia
+
+class DonVideo(private val attachment: Attachment) : MemoizeMedia(attachment.remoteUrl ?: attachment.url) {
+
+    override fun canPreview(): Boolean = false
+
+    override fun resolveMediaUrl(): String = attachment.remoteUrl ?: attachment.url
+
+    override fun resolveThumbnailUrl(): String = attachment.previewUrl
+}


### PR DESCRIPTION
アプリ内プレビューに対応するか決めかねていた時にサムネイル実装すら忘れていた。  
とりあえずサムネイル表示のみの対応としてMedia Classを作成して対応。