### PR TITLE
書記素単位に分割して草を生やす

### DIFF
--- a/Yukari/src/main/java/shibafu/yukari/activity/TweetActivity.java
+++ b/Yukari/src/main/java/shibafu/yukari/activity/TweetActivity.java
@@ -111,6 +111,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.text.BreakIterator;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -733,18 +734,26 @@ public class TweetActivity extends ActionBarYukariBase implements DraftDialogFra
                 appendTextInto("ｗ");
             } else {
                 String text = etInput.getText().toString().substring(Math.min(start, end), Math.max(start, end));
-                char[] chr = text.toCharArray();
-                int grass = text.length() - 1;
-                StringBuilder sb = new StringBuilder();
-                for (char c : chr) {
-                    sb.append(c);
-                    if (grass > 0) {
-                        sb.append("ｗ");
-                        --grass;
+                StringBuilder newText = new StringBuilder();
+
+                BreakIterator breakIterator = BreakIterator.getCharacterInstance();
+                breakIterator.setText(text);
+
+                int graphemeStart = breakIterator.first();
+                int graphemeEnd = breakIterator.next();
+
+                while (graphemeEnd != BreakIterator.DONE) {
+                    newText.append(text, graphemeStart, graphemeEnd);
+
+                    graphemeStart = graphemeEnd;
+                    graphemeEnd = breakIterator.next();
+
+                    if (graphemeEnd != BreakIterator.DONE) {
+                        newText.append("ｗ");
                     }
                 }
-                text = sb.toString();
-                etInput.getText().replace(Math.min(start, end), Math.max(start, end), text);
+
+                etInput.getText().replace(Math.min(start, end), Math.max(start, end), newText.toString());
             }
         });
 


### PR DESCRIPTION
「𠮷」のようなサロゲートペアを使った文字や、「👨‍👩‍👧」のような複数のコードポイントで構成された文字を含んだ文字列を選択して「ｗ」ボタンの長押しを実行すると、char単位でちぎられて文字列が崩壊する問題があった。

`BreakIterator` を用いて書記素単位に分割してから草を生やすことで、これらの文字を含んでいても正常に草が生えるようになる。

ただし、このAPIはAndroidのOSバージョン……おそらく各バージョンでの対応Unicodeバージョンの影響を受けるため、古い端末では期待通りに動かないこともある。

fix #214 
