### PR TITLE
twiccaプラグインボタンのアイコンサイズがたまに2倍くらいになる現象の対策

### DIFF
--- a/Yukari/src/main/java/shibafu/yukari/activity/TweetActivity.java
+++ b/Yukari/src/main/java/shibafu/yukari/activity/TweetActivity.java
@@ -888,9 +888,9 @@ public class TweetActivity extends ActionBarYukariBase implements DraftDialogFra
         List<ResolveInfo> plugins = pm.queryIntentActivities(query, PackageManager.MATCH_DEFAULT_ONLY);
         Collections.sort(plugins, new ResolveInfo.DisplayNameComparator(pm));
         llTweetExtra = (LinearLayout) findViewById(R.id.llTweetExtra);
-        // TODO: dimen resourceにしろバカ
-        float density = getResources().getDisplayMetrics().density;
-        LinearLayout.LayoutParams lpPluginButton = new LinearLayout.LayoutParams((int)(52 * density), (int)(48 * density));
+        LinearLayout.LayoutParams lpPluginButton = new LinearLayout.LayoutParams(
+                getResources().getDimensionPixelSize(R.dimen.tweet_plugin_button_width),
+                getResources().getDimensionPixelSize(R.dimen.tweet_plugin_button_height));
         for (ResolveInfo ri : plugins) {
             ImageButton imageButton = new AppCompatImageButton(this);
             imageButton.setImageDrawable(ri.activityInfo.loadIcon(pm));

--- a/Yukari/src/main/java/shibafu/yukari/activity/TweetActivity.java
+++ b/Yukari/src/main/java/shibafu/yukari/activity/TweetActivity.java
@@ -888,11 +888,13 @@ public class TweetActivity extends ActionBarYukariBase implements DraftDialogFra
         List<ResolveInfo> plugins = pm.queryIntentActivities(query, PackageManager.MATCH_DEFAULT_ONLY);
         Collections.sort(plugins, new ResolveInfo.DisplayNameComparator(pm));
         llTweetExtra = (LinearLayout) findViewById(R.id.llTweetExtra);
-        final int iconSize = (int) (getResources().getDisplayMetrics().density * PLUGIN_ICON_DIP);
+        // TODO: dimen resourceにしろバカ
+        float density = getResources().getDisplayMetrics().density;
+        LinearLayout.LayoutParams lpPluginButton = new LinearLayout.LayoutParams((int)(52 * density), (int)(48 * density));
         for (ResolveInfo ri : plugins) {
             ImageButton imageButton = new AppCompatImageButton(this);
-            Bitmap sourceIcon = ((BitmapDrawable) ri.activityInfo.loadIcon(pm)).getBitmap();
-            imageButton.setImageBitmap(Bitmap.createScaledBitmap(sourceIcon, iconSize, iconSize, true));
+            imageButton.setImageDrawable(ri.activityInfo.loadIcon(pm));
+            imageButton.setScaleType(ImageView.ScaleType.CENTER_INSIDE);
             imageButton.setTag(ri);
             imageButton.setOnClickListener(v -> {
                 ResolveInfo ri1 = (ResolveInfo) v.getTag();
@@ -924,7 +926,7 @@ public class TweetActivity extends ActionBarYukariBase implements DraftDialogFra
                 toast.show();
                 return true;
             });
-            llTweetExtra.addView(imageButton, FrameLayout.LayoutParams.WRAP_CONTENT, FrameLayout.LayoutParams.WRAP_CONTENT);
+            llTweetExtra.addView(imageButton, lpPluginButton);
         }
     }
 

--- a/Yukari/src/main/java/shibafu/yukari/activity/TweetActivity.java
+++ b/Yukari/src/main/java/shibafu/yukari/activity/TweetActivity.java
@@ -168,8 +168,6 @@ public class TweetActivity extends ActionBarYukariBase implements DraftDialogFra
     // PermissionsDispatcherが若いリクエスト番号を使うので、自前実装は大きめの番号から。
     private static final int PERMISSION_REQUEST_INIT_ATTACH = 0x1000;
 
-    private static final int PLUGIN_ICON_DIP = 28;
-
     private static final int TITLE_AREA_MAX_LINES = 3;
 
     private static final Pattern PATTERN_PREFIX = Pattern.compile("(@[0-9a-zA-Z_]{1,15} )+.*");
@@ -1702,12 +1700,14 @@ public class TweetActivity extends ActionBarYukariBase implements DraftDialogFra
                     final String slug = Optional.ofNullable((String) entry.get("slug")).orElse("missing_slug");
                     final String label = Optional.ofNullable((String) entry.get("label")).orElse(slug);
                     final ProcWrapper exec = (ProcWrapper) entry.get("exec");
-                    final int iconSize = (int) (getResources().getDisplayMetrics().density * PLUGIN_ICON_DIP);
+                    final LinearLayout.LayoutParams lpPluginButton = new LinearLayout.LayoutParams(
+                            getResources().getDimensionPixelSize(R.dimen.tweet_plugin_button_width),
+                            getResources().getDimensionPixelSize(R.dimen.tweet_plugin_button_height));
                     {
                         ImageButton imageButton = new AppCompatImageButton(this);
-                        Bitmap sourceIcon = BitmapFactory.decodeResource(getResources(), R.drawable.ic_launcher_tweet);
-                        imageButton.setImageBitmap(Bitmap.createScaledBitmap(sourceIcon, iconSize, iconSize, true));
+                        imageButton.setImageResource(R.drawable.ic_launcher_tweet);
                         imageButton.setTag(exec);
+                        imageButton.setScaleType(ImageView.ScaleType.CENTER_INSIDE);
                         imageButton.setOnClickListener(v -> {
                             Map<String, String> extra = new LinkedHashMap<>();
 
@@ -1760,7 +1760,7 @@ public class TweetActivity extends ActionBarYukariBase implements DraftDialogFra
                             toast.show();
                             return true;
                         });
-                        llTweetExtra.addView(imageButton, FrameLayout.LayoutParams.WRAP_CONTENT, FrameLayout.LayoutParams.WRAP_CONTENT);
+                        llTweetExtra.addView(imageButton, lpPluginButton);
                     }
                 });
                 isLoadedPluggaloid = true;

--- a/Yukari/src/main/res/values/dimens.xml
+++ b/Yukari/src/main/res/values/dimens.xml
@@ -20,4 +20,7 @@
     <dimen name="status_button_delta_half">50dp</dimen>
 
     <dimen name="attach_picture_size">78dp</dimen>
+
+    <dimen name="tweet_plugin_button_width">52dp</dimen>
+    <dimen name="tweet_plugin_button_height">48dp</dimen>
 </resources>


### PR DESCRIPTION
なぜか下図のようになることがあったので、アイコンのBitmapをリサイズするのではなく、Viewを固定サイズにした。

![2019-05-14 00 28 23](https://user-images.githubusercontent.com/1352154/57863041-561ec380-7834-11e9-9ffb-eaee6d8fd6d3.png)
