### PR TITLE
WIP: 下書きのInReplyTo情報にProviderごとのローカルIDを補足できるようにする

### DIFF
--- a/Yukari/src/main/java/shibafu/yukari/activity/TweetActivity.java
+++ b/Yukari/src/main/java/shibafu/yukari/activity/TweetActivity.java
@@ -1610,7 +1610,7 @@ public class TweetActivity extends ActionBarYukariBase implements DraftDialogFra
                     writers,
                     etInput.getText().toString(),
                     System.currentTimeMillis(),
-                    status == null ? null : status.getInReplyToId(),
+                    status == null ? null : status.getInReplyTo(),
                     false,
                     AttachPicture.toUriList(attachPictures),
                     false,
@@ -1625,7 +1625,7 @@ public class TweetActivity extends ActionBarYukariBase implements DraftDialogFra
         } else {
             draft.setWriters(writers);
             draft.setText(etInput.getText().toString());
-            draft.setInReplyTo(status == null ? null : status.getInReplyToId());
+            draft.setInReplyTo(status == null ? null : status.getInReplyTo());
             draft.setQuoted(false);
             draft.setAttachPictures(AttachPicture.toUriList(attachPictures));
             draft.setUseGeoLocation(false);

--- a/Yukari/src/main/java/shibafu/yukari/activity/TweetActivity.java
+++ b/Yukari/src/main/java/shibafu/yukari/activity/TweetActivity.java
@@ -80,6 +80,7 @@ import shibafu.yukari.common.FontAsset;
 import shibafu.yukari.common.UsedHashes;
 import shibafu.yukari.common.async.SimpleAsyncTask;
 import shibafu.yukari.database.Provider;
+import shibafu.yukari.entity.InReplyToId;
 import shibafu.yukari.entity.Status;
 import shibafu.yukari.entity.StatusDraft;
 import shibafu.yukari.fragment.DraftDialogFragment;
@@ -1577,7 +1578,7 @@ public class TweetActivity extends ActionBarYukariBase implements DraftDialogFra
                         writers,
                         etInput.getText().toString(),
                         System.currentTimeMillis(),
-                        String.valueOf(directMessageDestId),
+                        new InReplyToId(String.valueOf(directMessageDestId)),
                         false,
                         AttachPicture.toUriList(attachPictures),
                         false,
@@ -1592,7 +1593,7 @@ public class TweetActivity extends ActionBarYukariBase implements DraftDialogFra
             } else {
                 draft.setWriters(writers);
                 draft.setText(etInput.getText().toString());
-                draft.setInReplyTo(String.valueOf(directMessageDestId));
+                draft.setInReplyTo(new InReplyToId(String.valueOf(directMessageDestId)));
                 draft.setQuoted(false);
                 draft.setAttachPictures(AttachPicture.toUriList(attachPictures));
                 draft.setUseGeoLocation(false);
@@ -1609,7 +1610,7 @@ public class TweetActivity extends ActionBarYukariBase implements DraftDialogFra
                     writers,
                     etInput.getText().toString(),
                     System.currentTimeMillis(),
-                    (status == null) ? null : status.getUrl(),
+                    (status == null || status.getUrl() == null) ? null : new InReplyToId(status.getUrl()),
                     false,
                     AttachPicture.toUriList(attachPictures),
                     false,
@@ -1624,7 +1625,7 @@ public class TweetActivity extends ActionBarYukariBase implements DraftDialogFra
         } else {
             draft.setWriters(writers);
             draft.setText(etInput.getText().toString());
-            draft.setInReplyTo((status == null) ? null : status.getUrl());
+            draft.setInReplyTo((status == null || status.getUrl() == null) ? null : new InReplyToId(status.getUrl()));
             draft.setQuoted(false);
             draft.setAttachPictures(AttachPicture.toUriList(attachPictures));
             draft.setUseGeoLocation(false);

--- a/Yukari/src/main/java/shibafu/yukari/activity/TweetActivity.java
+++ b/Yukari/src/main/java/shibafu/yukari/activity/TweetActivity.java
@@ -1610,7 +1610,7 @@ public class TweetActivity extends ActionBarYukariBase implements DraftDialogFra
                     writers,
                     etInput.getText().toString(),
                     System.currentTimeMillis(),
-                    (status == null || status.getUrl() == null) ? null : new InReplyToId(status.getUrl()),
+                    status == null ? null : status.getInReplyToId(),
                     false,
                     AttachPicture.toUriList(attachPictures),
                     false,
@@ -1625,7 +1625,7 @@ public class TweetActivity extends ActionBarYukariBase implements DraftDialogFra
         } else {
             draft.setWriters(writers);
             draft.setText(etInput.getText().toString());
-            draft.setInReplyTo((status == null || status.getUrl() == null) ? null : new InReplyToId(status.getUrl()));
+            draft.setInReplyTo(status == null ? null : status.getInReplyToId());
             draft.setQuoted(false);
             draft.setAttachPictures(AttachPicture.toUriList(attachPictures));
             draft.setUseGeoLocation(false);

--- a/Yukari/src/main/java/shibafu/yukari/entity/InReplyToId.kt
+++ b/Yukari/src/main/java/shibafu/yukari/entity/InReplyToId.kt
@@ -1,0 +1,16 @@
+package shibafu.yukari.entity
+
+/**
+ * 返信先の識別情報を格納するクラス。
+ *
+ * URL形式での表現を1つ持つことが必須要件で、Providerの仕様に応じて追加の識別情報を持たせても良い。
+ */
+class InReplyToId(val url: String) {
+    private val perProviderId = HashMap<String, String>()
+
+    operator fun get(apiType: Int, host: String): String? = perProviderId["$apiType@$host"]
+
+    operator fun set(apiType: Int, host: String, value: String) {
+        perProviderId["$apiType@$host"] = value
+    }
+}

--- a/Yukari/src/main/java/shibafu/yukari/entity/InReplyToId.kt
+++ b/Yukari/src/main/java/shibafu/yukari/entity/InReplyToId.kt
@@ -1,16 +1,55 @@
 package shibafu.yukari.entity
 
+import android.os.Parcel
+import android.os.Parcelable
+
 /**
  * 返信先の識別情報を格納するクラス。
  *
  * URL形式での表現を1つ持つことが必須要件で、Providerの仕様に応じて追加の識別情報を持たせても良い。
  */
-class InReplyToId(val url: String) {
+class InReplyToId(val url: String) : Parcelable {
     private val perProviderId = HashMap<String, String>()
+
+    constructor(parcel: Parcel) : this(parcel.readString().orEmpty()) {
+        val perProviderIdSize = parcel.readInt()
+        for (i in 0 until perProviderIdSize) {
+            val key = parcel.readString() ?: continue
+            val value = parcel.readString() ?: continue
+            perProviderId[key] = value
+        }
+    }
+
+    override fun writeToParcel(dest: Parcel?, flags: Int) {
+        if (dest == null) {
+            return
+        }
+
+        dest.writeString(url)
+        dest.writeInt(perProviderId.size)
+        perProviderId.forEach { kv ->
+            dest.writeString(kv.key)
+            dest.writeString(kv.value)
+        }
+    }
+
+    override fun describeContents(): Int = 0
 
     operator fun get(apiType: Int, host: String): String? = perProviderId["$apiType@$host"]
 
     operator fun set(apiType: Int, host: String, value: String) {
         perProviderId["$apiType@$host"] = value
+    }
+
+    companion object {
+        @JvmField val CREATOR = object : Parcelable.Creator<InReplyToId> {
+            override fun createFromParcel(parcel: Parcel): InReplyToId {
+                return InReplyToId(parcel)
+            }
+
+            override fun newArray(size: Int): Array<InReplyToId?> {
+                return arrayOfNulls(size)
+            }
+        }
     }
 }

--- a/Yukari/src/main/java/shibafu/yukari/entity/InReplyToId.kt
+++ b/Yukari/src/main/java/shibafu/yukari/entity/InReplyToId.kt
@@ -2,6 +2,7 @@ package shibafu.yukari.entity
 
 import android.os.Parcel
 import android.os.Parcelable
+import com.google.gson.Gson
 
 /**
  * 返信先の識別情報を格納するクラス。
@@ -41,6 +42,8 @@ class InReplyToId(val url: String) : Parcelable {
         perProviderId["$apiType@$host"] = value
     }
 
+    fun toJson(gson: Gson = Gson()): String = gson.toJson(this)
+
     companion object {
         @JvmField val CREATOR = object : Parcelable.Creator<InReplyToId> {
             override fun createFromParcel(parcel: Parcel): InReplyToId {
@@ -49,6 +52,17 @@ class InReplyToId(val url: String) : Parcelable {
 
             override fun newArray(size: Int): Array<InReplyToId?> {
                 return arrayOfNulls(size)
+            }
+        }
+
+        /**
+         * 過去のInReplyTo永続化との互換用。JSON Objectっぽい場合はJSONとしてデシリアライズして、それ以外の場合はとりあえずURLとして解釈する。
+         */
+        fun fromString(jsonOrString: String, gson: Gson = Gson()): InReplyToId {
+            if (jsonOrString.startsWith("{")) {
+                return gson.fromJson<InReplyToId>(jsonOrString, InReplyToId::class.java)
+            } else {
+                return InReplyToId(jsonOrString)
             }
         }
     }

--- a/Yukari/src/main/java/shibafu/yukari/entity/Status.kt
+++ b/Yukari/src/main/java/shibafu/yukari/entity/Status.kt
@@ -211,6 +211,8 @@ interface Status : Comparable<Status>, Serializable {
         }
     }
 
+    fun getInReplyToId(): InReplyToId = InReplyToId(url.orEmpty())
+
     override fun compareTo(other: Status): Int {
         if (this === other) return 0
 

--- a/Yukari/src/main/java/shibafu/yukari/entity/Status.kt
+++ b/Yukari/src/main/java/shibafu/yukari/entity/Status.kt
@@ -211,7 +211,7 @@ interface Status : Comparable<Status>, Serializable {
         }
     }
 
-    fun getInReplyToId(): InReplyToId = InReplyToId(url.orEmpty())
+    fun getInReplyTo(): InReplyToId = InReplyToId(url.orEmpty())
 
     override fun compareTo(other: Status): Int {
         if (this === other) return 0

--- a/Yukari/src/main/java/shibafu/yukari/fragment/DraftDialogFragment.java
+++ b/Yukari/src/main/java/shibafu/yukari/fragment/DraftDialogFragment.java
@@ -173,7 +173,7 @@ public class DraftDialogFragment extends DialogFragment {
                 TextView tvTimestamp = (TextView)v.findViewById(R.id.tweet_timestamp);
                 String info = "";
                 if (d.isDirectMessage()) {
-                    DBUser dbUser = service.getDatabase().getUser(d.getInReplyTo());
+                    DBUser dbUser = service.getDatabase().getUser(Long.valueOf(d.getInReplyTo().getUrl()));
                     info += "DM to " + (dbUser!=null? "@" + dbUser.getScreenName() : "(Unknown User)") + "\n";
                 }
                 if (d.isFailedDelivery()) {

--- a/Yukari/src/main/java/shibafu/yukari/mastodon/MastodonApi.kt
+++ b/Yukari/src/main/java/shibafu/yukari/mastodon/MastodonApi.kt
@@ -118,9 +118,9 @@ class MastodonApi : ProviderApi {
             }
 
             // 返信先URLが設定されている場合は対象のインスタンスローカルなIDを取得
-            val inReplyToUrl = draft.inReplyTo
-            val inReplyToId = if (inReplyToUrl != null && inReplyToUrl.isNotEmpty()) {
-                showStatus(userRecord, inReplyToUrl).id
+            val inReplyTo = draft.inReplyTo
+            val inReplyToId = if (inReplyTo != null) {
+                showStatus(userRecord, inReplyTo.url).id
             } else {
                 null
             }

--- a/Yukari/src/main/java/shibafu/yukari/mastodon/MastodonApi.kt
+++ b/Yukari/src/main/java/shibafu/yukari/mastodon/MastodonApi.kt
@@ -15,6 +15,7 @@ import okhttp3.MediaType
 import okhttp3.MultipartBody
 import okhttp3.OkHttpClient
 import okhttp3.RequestBody
+import shibafu.yukari.database.Provider
 import shibafu.yukari.entity.Status
 import shibafu.yukari.entity.StatusDraft
 import shibafu.yukari.linkage.PostValidator
@@ -117,10 +118,11 @@ class MastodonApi : ProviderApi {
                 StatusDraft.Visibility.DIRECT -> Visibility.Direct
             }
 
-            // 返信先URLが設定されている場合は対象のインスタンスローカルなIDを取得
+            // 返信先が設定されている場合、対象のインスタンスローカルなIDが埋め込まれていればそのIDを使用する
+            // インスタンスローカルなIDが未知の場合は、サーバからの取得を試みる
             val inReplyTo = draft.inReplyTo
             val inReplyToId = if (inReplyTo != null) {
-                showStatus(userRecord, inReplyTo.url).id
+                inReplyTo[Provider.API_MASTODON, userRecord.Provider.host]?.toLong() ?: showStatus(userRecord, inReplyTo.url).id
             } else {
                 null
             }

--- a/Yukari/src/main/java/shibafu/yukari/mastodon/entity/DonStatus.kt
+++ b/Yukari/src/main/java/shibafu/yukari/mastodon/entity/DonStatus.kt
@@ -132,8 +132,8 @@ class DonStatus(val status: Status,
         }
     }
 
-    override fun getInReplyToId(): InReplyToId {
-        val inReplyTo = super.getInReplyToId()
+    override fun getInReplyTo(): InReplyToId {
+        val inReplyTo = super.getInReplyTo()
         perProviderId.forEachKeyValue { key, value ->
             inReplyTo[Provider.API_MASTODON, key] = value.toString()
         }

--- a/Yukari/src/main/java/shibafu/yukari/mastodon/entity/DonStatus.kt
+++ b/Yukari/src/main/java/shibafu/yukari/mastodon/entity/DonStatus.kt
@@ -5,11 +5,13 @@ import android.os.Parcelable
 import android.util.Xml
 import com.google.gson.Gson
 import com.sys1yagi.mastodon4j.api.entity.Status
+import org.eclipse.collections.impl.map.mutable.primitive.ObjectLongHashMap
 import org.threeten.bp.DateTimeUtils
 import org.threeten.bp.ZonedDateTime
 import org.xmlpull.v1.XmlPullParser
 import org.xmlpull.v1.XmlPullParserFactory
 import shibafu.yukari.database.Provider
+import shibafu.yukari.entity.InReplyToId
 import shibafu.yukari.entity.Mention
 import shibafu.yukari.entity.StatusPreforms
 import shibafu.yukari.entity.User
@@ -70,6 +72,9 @@ class DonStatus(val status: Status,
 
     val isLocal: Boolean = status.application != null
 
+    var perProviderId = ObjectLongHashMap.newWithKeysValues(representUser.Provider.host, status.id)
+        private set
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is DonStatus) return false
@@ -114,11 +119,25 @@ class DonStatus(val status: Status,
         super.merge(status)
 
         // ローカルトゥートを優先
-        if (status is DonStatus && !this.isLocal && status.isLocal) {
-            return status
+        if (status is DonStatus) {
+            if (!this.isLocal && status.isLocal) {
+                status.perProviderId.putAll(perProviderId)
+                return status
+            } else {
+                perProviderId.putAll(status.perProviderId)
+                return this
+            }
         } else {
             return this
         }
+    }
+
+    override fun getInReplyToId(): InReplyToId {
+        val inReplyTo = super.getInReplyToId()
+        perProviderId.forEachKeyValue { key, value ->
+            inReplyTo[Provider.API_MASTODON, key] = value.toString()
+        }
+        return inReplyTo
     }
 
     init {
@@ -206,6 +225,12 @@ class DonStatus(val status: Status,
             it.writeInt(favoritesCount)
             it.writeInt(repostsCount)
             it.writeList(receivedUsers)
+
+            it.writeInt(perProviderId.size())
+            perProviderId.forEachKeyValue { key, value ->
+                it.writeString(key)
+                it.writeLong(value)
+            }
         }
     }
 
@@ -220,6 +245,16 @@ class DonStatus(val status: Status,
                 donStatus.favoritesCount = source.readInt()
                 donStatus.repostsCount = source.readInt()
                 donStatus.receivedUsers = source.readArrayList(this.javaClass.classLoader) as MutableList<AuthUserRecord>
+
+                val perProviderIdSize = source.readInt()
+                val perProviderId = ObjectLongHashMap<String>(perProviderIdSize)
+                for (i in 0 until perProviderIdSize) {
+                    val key = source.readString()
+                    val value = source.readLong()
+                    perProviderId.put(key, value)
+                }
+                donStatus.perProviderId = perProviderId
+
                 return donStatus
             }
 

--- a/Yukari/src/main/java/shibafu/yukari/service/PostService.java
+++ b/Yukari/src/main/java/shibafu/yukari/service/PostService.java
@@ -20,6 +20,7 @@ import android.util.Log;
 import shibafu.yukari.R;
 import shibafu.yukari.activity.TweetActivity;
 import shibafu.yukari.common.bitmapcache.BitmapCache;
+import shibafu.yukari.entity.InReplyToId;
 import shibafu.yukari.entity.Status;
 import shibafu.yukari.entity.StatusDraft;
 import shibafu.yukari.linkage.ProviderApi;
@@ -302,13 +303,15 @@ public class PostService extends IntentService{
                 long inReplyToId = intent.getLongExtra(TweetActivity.EXTRA_IN_REPLY_TO, -1);
 
                 draft.setMessageTarget(targetSN);
-                draft.setInReplyTo(String.valueOf(inReplyToId));
+                draft.setInReplyTo(new InReplyToId(String.valueOf(inReplyToId)));
                 draft.setDirectMessage(true);
                 draft.setText(String.valueOf(voiceInput));
             } else {
                 Status inReplyToStatus = (Status) intent.getSerializableExtra(TweetActivity.EXTRA_STATUS);
 
-                draft.setInReplyTo(inReplyToStatus.getUrl());
+                if (inReplyToStatus.getUrl() != null) {
+                    draft.setInReplyTo(new InReplyToId(inReplyToStatus.getUrl()));
+                }
                 draft.setText(prefix + voiceInput);
             }
 

--- a/Yukari/src/main/java/shibafu/yukari/service/PostService.java
+++ b/Yukari/src/main/java/shibafu/yukari/service/PostService.java
@@ -309,9 +309,7 @@ public class PostService extends IntentService{
             } else {
                 Status inReplyToStatus = (Status) intent.getSerializableExtra(TweetActivity.EXTRA_STATUS);
 
-                if (inReplyToStatus.getUrl() != null) {
-                    draft.setInReplyTo(new InReplyToId(inReplyToStatus.getUrl()));
-                }
+                draft.setInReplyTo(inReplyToStatus.getInReplyToId());
                 draft.setText(prefix + voiceInput);
             }
 

--- a/Yukari/src/main/java/shibafu/yukari/service/PostService.java
+++ b/Yukari/src/main/java/shibafu/yukari/service/PostService.java
@@ -309,7 +309,7 @@ public class PostService extends IntentService{
             } else {
                 Status inReplyToStatus = (Status) intent.getSerializableExtra(TweetActivity.EXTRA_STATUS);
 
-                draft.setInReplyTo(inReplyToStatus.getInReplyToId());
+                draft.setInReplyTo(inReplyToStatus.getInReplyTo());
                 draft.setText(prefix + voiceInput);
             }
 

--- a/Yukari/src/main/java/shibafu/yukari/twitter/TwitterApi.kt
+++ b/Yukari/src/main/java/shibafu/yukari/twitter/TwitterApi.kt
@@ -162,7 +162,7 @@ class TwitterApi : ProviderApi {
         val twitter = service.getTwitter(userRecord) ?: throw IllegalStateException("Twitterとの通信の準備に失敗しました")
         try {
             if (draft.isDirectMessage) {
-                val inReplyTo = draft.inReplyTo?.toLongOrNull() ?: throw ProviderApiException("返信先に不正な値が指定されました。")
+                val inReplyTo = draft.inReplyTo?.url?.toLongOrNull() ?: throw ProviderApiException("返信先に不正な値が指定されました。")
                 val users = twitter.lookupUsers(inReplyTo, userRecord.NumericId)
                 val result = twitter.sendDirectMessage(inReplyTo, draft.text)
                 return TwitterMessage(result,
@@ -188,10 +188,11 @@ class TwitterApi : ProviderApi {
                 }
 
                 // 返信先URLが設定されている場合はin-reply-toに設定する
-                if (!draft.inReplyTo.isNullOrEmpty()) {
-                    val inReplyTo = TwitterUtil.getStatusIdFromUrl(draft.inReplyTo)
-                    if (inReplyTo > -1) {
-                        update.inReplyToStatusId = inReplyTo
+                val inReplyTo = draft.inReplyTo
+                if (inReplyTo != null) {
+                    val inReplyToId = TwitterUtil.getStatusIdFromUrl(inReplyTo.url)
+                    if (inReplyToId > -1) {
+                        update.inReplyToStatusId = inReplyToId
                     }
                 }
 


### PR DESCRIPTION
fix #167

下書きのInReplyTo情報をURL化したのは良かったが、Mastodonでは返信先の公開範囲が「フォロワー限定」「ダイレクト」の場合にURL→ID変換ができずに返信不能になってしまう問題を抱えてしまった。

このため、返信を開始した時点では見えているはずの「サーバーローカルなID」をそのまま送信の時まで保持する必要がある。

## TODO
- [x] `Drafts.InReplyTo` を拡張して、Provider単位でローカルIDを持たせられるようにする
- [x] DonStatusを拡張して、マージ時にProviderとIDの対応を残すようにする
- [x] StatusDraftの生成時に、どうにかして上記の対応を渡す
