### PR TITLE
DM下書きの返信先情報をURLとしてマイグレーション

### DIFF
--- a/Yukari/src/main/java/shibafu/yukari/activity/TweetActivity.java
+++ b/Yukari/src/main/java/shibafu/yukari/activity/TweetActivity.java
@@ -95,6 +95,7 @@ import shibafu.yukari.service.TwitterService;
 import shibafu.yukari.twitter.AuthUserRecord;
 import shibafu.yukari.twitter.TweetValidator;
 import shibafu.yukari.twitter.TwitterApi;
+import shibafu.yukari.twitter.TwitterUtil;
 import shibafu.yukari.twitter.entity.TwitterStatus;
 import shibafu.yukari.twitter.statusimpl.PreformedStatus;
 import shibafu.yukari.util.AttrUtil;
@@ -1577,7 +1578,7 @@ public class TweetActivity extends ActionBarYukariBase implements DraftDialogFra
                         writers,
                         etInput.getText().toString(),
                         System.currentTimeMillis(),
-                        String.valueOf(directMessageDestId),
+                        TwitterUtil.getUrlFromUserId(directMessageDestId),
                         false,
                         AttachPicture.toUriList(attachPictures),
                         false,
@@ -1592,7 +1593,7 @@ public class TweetActivity extends ActionBarYukariBase implements DraftDialogFra
             } else {
                 draft.setWriters(writers);
                 draft.setText(etInput.getText().toString());
-                draft.setInReplyTo(String.valueOf(directMessageDestId));
+                draft.setInReplyTo(TwitterUtil.getUrlFromUserId(directMessageDestId));
                 draft.setQuoted(false);
                 draft.setAttachPictures(AttachPicture.toUriList(attachPictures));
                 draft.setUseGeoLocation(false);

--- a/Yukari/src/main/java/shibafu/yukari/activity/TweetActivity.java
+++ b/Yukari/src/main/java/shibafu/yukari/activity/TweetActivity.java
@@ -378,7 +378,7 @@ public class TweetActivity extends ActionBarYukariBase implements DraftDialogFra
         //DM判定
         isDirectMessage = args.getIntExtra(EXTRA_MODE, MODE_TWEET) == MODE_DM;
         if (isDirectMessage) {
-            directMessageDestId = args.getLongExtra(EXTRA_IN_REPLY_TO, -1);
+            directMessageDestId = TwitterUtil.getUserIdFromUrl(args.getStringExtra(EXTRA_IN_REPLY_TO));
             directMessageDestSN = args.getStringExtra(EXTRA_DM_TARGET_SN);
             //表題変更
             tvTitle.setText("DirectMessage to @" + directMessageDestSN);

--- a/Yukari/src/main/java/shibafu/yukari/database/CentralDatabase.java
+++ b/Yukari/src/main/java/shibafu/yukari/database/CentralDatabase.java
@@ -588,7 +588,11 @@ public class CentralDatabase {
                         COL_DRAFTS_WRITER_ID + ", " +
                         COL_DRAFTS_TEXT + ", " +
                         COL_DRAFTS_DATETIME + ", " +
-                        "CASE WHEN " + COL_DRAFTS_IN_REPLY_TO + " IS NULL OR " + COL_DRAFTS_IN_REPLY_TO + " <= 0 THEN NULL ELSE 'https://twitter.com/null/status/'||" + COL_DRAFTS_IN_REPLY_TO + " END, " +
+                        "CASE WHEN " + COL_DRAFTS_IN_REPLY_TO + " IS NULL OR " + COL_DRAFTS_IN_REPLY_TO + " <= 0 THEN NULL " +
+                        "     ELSE CASE WHEN " + COL_DRAFTS_IS_DIRECT_MESSAGE + " = 1 THEN 'https://twitter.com/intent/user?user_id='||" + COL_DRAFTS_IN_REPLY_TO +
+                        "               ELSE 'https://twitter.com/null/status/'||" + COL_DRAFTS_IN_REPLY_TO +
+                        "          END " +
+                        " END, " +
                         COL_DRAFTS_IS_QUOTED + ", " +
                         COL_DRAFTS_ATTACHED_PICTURE + ", " +
                         COL_DRAFTS_USE_GEO_LOCATION + ", " +
@@ -599,7 +603,7 @@ public class CentralDatabase {
                         COL_DRAFTS_IS_FAILED_DELIVERY + ", " +
                         COL_DRAFTS_MESSAGE_TARGET + ", " +
                         "0, " +
-                        "NULL, " +
+                        "NULL " +
                         " FROM tmp_Drafts"
                 );
                 db.execSQL("DROP TABLE tmp_Drafts");

--- a/Yukari/src/main/java/shibafu/yukari/fragment/DraftDialogFragment.java
+++ b/Yukari/src/main/java/shibafu/yukari/fragment/DraftDialogFragment.java
@@ -20,6 +20,7 @@ import shibafu.yukari.entity.StatusDraft;
 import shibafu.yukari.service.TwitterService;
 import shibafu.yukari.service.TwitterServiceDelegate;
 import shibafu.yukari.twitter.AuthUserRecord;
+import shibafu.yukari.twitter.TwitterUtil;
 
 import java.text.SimpleDateFormat;
 import java.util.List;
@@ -173,7 +174,7 @@ public class DraftDialogFragment extends DialogFragment {
                 TextView tvTimestamp = (TextView)v.findViewById(R.id.tweet_timestamp);
                 String info = "";
                 if (d.isDirectMessage()) {
-                    DBUser dbUser = service.getDatabase().getUser(d.getInReplyTo());
+                    DBUser dbUser = service.getDatabase().getUser(TwitterUtil.getUserIdFromUrl(d.getInReplyTo()));
                     info += "DM to " + (dbUser!=null? "@" + dbUser.getScreenName() : "(Unknown User)") + "\n";
                 }
                 if (d.isFailedDelivery()) {

--- a/Yukari/src/main/java/shibafu/yukari/fragment/ProfileFragment.java
+++ b/Yukari/src/main/java/shibafu/yukari/fragment/ProfileFragment.java
@@ -834,7 +834,7 @@ public class ProfileFragment extends YukariBaseFragment implements FollowDialogF
             case R.id.action_send_message: {
                 Intent intent = new Intent(getActivity(), TweetActivity.class);
                 intent.putExtra(TweetActivity.EXTRA_MODE, TweetActivity.MODE_DM);
-                intent.putExtra(TweetActivity.EXTRA_IN_REPLY_TO, loadHolder.targetUser.getId());
+                intent.putExtra(TweetActivity.EXTRA_IN_REPLY_TO, TwitterUtil.getUrlFromUserId(loadHolder.targetUser.getId()));
                 intent.putExtra(TweetActivity.EXTRA_DM_TARGET_SN, loadHolder.targetUser.getScreenName());
                 startActivity(intent);
                 return true;

--- a/Yukari/src/main/java/shibafu/yukari/fragment/status/StatusLinkFragment.kt
+++ b/Yukari/src/main/java/shibafu/yukari/fragment/status/StatusLinkFragment.kt
@@ -34,6 +34,7 @@ import shibafu.yukari.fragment.base.ListYukariBaseFragment
 import shibafu.yukari.fragment.tabcontent.TweetListFragment
 import shibafu.yukari.media2.Media
 import shibafu.yukari.twitter.AuthUserRecord
+import shibafu.yukari.twitter.TwitterUtil
 import shibafu.yukari.twitter.entity.TwitterStatus
 import shibafu.yukari.twitter.entity.TwitterUser
 import shibafu.yukari.util.defaultSharedPreferences
@@ -386,7 +387,7 @@ class StatusLinkFragment : ListYukariBaseFragment(), StatusChildUI {
                     Intent(activity, TweetActivity::class.java).apply {
                         putExtra(TweetActivity.EXTRA_USER, userRecord)
                         putExtra(TweetActivity.EXTRA_MODE, TweetActivity.MODE_DM)
-                        putExtra(TweetActivity.EXTRA_IN_REPLY_TO, id)
+                        putExtra(TweetActivity.EXTRA_IN_REPLY_TO, TwitterUtil.getUrlFromUserId(user.id))
                         putExtra(TweetActivity.EXTRA_DM_TARGET_SN, user.screenName)
                     }
                 }

--- a/Yukari/src/main/java/shibafu/yukari/fragment/tabcontent/TimelineFragment.kt
+++ b/Yukari/src/main/java/shibafu/yukari/fragment/tabcontent/TimelineFragment.kt
@@ -50,6 +50,7 @@ import shibafu.yukari.linkage.TimelineObserver
 import shibafu.yukari.mastodon.entity.DonStatus
 import shibafu.yukari.media2.Media
 import shibafu.yukari.twitter.AuthUserRecord
+import shibafu.yukari.twitter.TwitterUtil
 import shibafu.yukari.twitter.entity.TwitterMessage
 import shibafu.yukari.twitter.entity.TwitterStatus
 import shibafu.yukari.util.AttrUtil
@@ -495,7 +496,7 @@ open class TimelineFragment : ListYukariBaseFragment(), TimelineTab, TimelineObs
                         val intent = Intent(activity, TweetActivity::class.java)
                         intent.putExtra(TweetActivity.EXTRA_USER, status.representUser)
                         intent.putExtra(TweetActivity.EXTRA_MODE, TweetActivity.MODE_DM)
-                        intent.putExtra(TweetActivity.EXTRA_IN_REPLY_TO, status.user.id)
+                        intent.putExtra(TweetActivity.EXTRA_IN_REPLY_TO, TwitterUtil.getUrlFromUserId(status.user.id))
                         intent.putExtra(TweetActivity.EXTRA_DM_TARGET_SN, status.user.screenName)
                         startActivity(intent)
                     }

--- a/Yukari/src/main/java/shibafu/yukari/linkage/StatusNotifier.java
+++ b/Yukari/src/main/java/shibafu/yukari/linkage/StatusNotifier.java
@@ -29,6 +29,7 @@ import shibafu.yukari.entity.Status;
 import shibafu.yukari.entity.User;
 import shibafu.yukari.service.PostService;
 import shibafu.yukari.service.TwitterService;
+import shibafu.yukari.twitter.TwitterUtil;
 import shibafu.yukari.util.CompatUtil;
 import shibafu.yukari.util.Releasable;
 
@@ -323,7 +324,7 @@ public class StatusNotifier implements Releasable {
                             Intent replyIntent = new Intent(context.getApplicationContext(), TweetActivity.class);
                             replyIntent.putExtra(TweetActivity.EXTRA_USER, status.getRepresentUser());
                             replyIntent.putExtra(TweetActivity.EXTRA_MODE, TweetActivity.MODE_DM);
-                            replyIntent.putExtra(TweetActivity.EXTRA_IN_REPLY_TO, status.getUser().getId());
+                            replyIntent.putExtra(TweetActivity.EXTRA_IN_REPLY_TO, TwitterUtil.getUrlFromUserId(status.getUser().getId()));
                             replyIntent.putExtra(TweetActivity.EXTRA_DM_TARGET_SN, status.getUser().getScreenName());
                             builder.addAction(R.drawable.ic_stat_message, "返信", PendingIntent.getActivity(
                                             context.getApplicationContext(), R.integer.notification_message, replyIntent, PendingIntent.FLAG_UPDATE_CURRENT)
@@ -333,7 +334,7 @@ public class StatusNotifier implements Releasable {
                             Intent voiceReplyIntent = new Intent(context.getApplicationContext(), PostService.class);
                             voiceReplyIntent.putExtra(TweetActivity.EXTRA_USER, status.getRepresentUser());
                             voiceReplyIntent.putExtra(TweetActivity.EXTRA_MODE, TweetActivity.MODE_DM);
-                            voiceReplyIntent.putExtra(TweetActivity.EXTRA_IN_REPLY_TO, status.getUser().getId());
+                            voiceReplyIntent.putExtra(TweetActivity.EXTRA_IN_REPLY_TO, TwitterUtil.getUrlFromUserId(status.getUser().getId()));
                             voiceReplyIntent.putExtra(TweetActivity.EXTRA_DM_TARGET_SN, status.getUser().getScreenName());
                             NotificationCompat.Action voiceReply = new NotificationCompat.Action
                                     .Builder(R.drawable.ic_stat_reply, "声で返信",

--- a/Yukari/src/main/java/shibafu/yukari/service/PostService.java
+++ b/Yukari/src/main/java/shibafu/yukari/service/PostService.java
@@ -25,7 +25,6 @@ import shibafu.yukari.entity.StatusDraft;
 import shibafu.yukari.linkage.ProviderApi;
 import shibafu.yukari.linkage.ProviderApiException;
 import shibafu.yukari.twitter.AuthUserRecord;
-import shibafu.yukari.twitter.TwitterUtil;
 import shibafu.yukari.util.BitmapUtil;
 import shibafu.yukari.util.CompatUtil;
 
@@ -300,10 +299,10 @@ public class PostService extends IntentService{
 
             if (mode == TweetActivity.MODE_DM) {
                 String targetSN = intent.getStringExtra(TweetActivity.EXTRA_DM_TARGET_SN);
-                long inReplyToId = intent.getLongExtra(TweetActivity.EXTRA_IN_REPLY_TO, -1);
+                String inReplyTo = intent.getStringExtra(TweetActivity.EXTRA_IN_REPLY_TO);
 
                 draft.setMessageTarget(targetSN);
-                draft.setInReplyTo(TwitterUtil.getUrlFromUserId(inReplyToId));
+                draft.setInReplyTo(inReplyTo);
                 draft.setDirectMessage(true);
                 draft.setText(String.valueOf(voiceInput));
             } else {

--- a/Yukari/src/main/java/shibafu/yukari/service/PostService.java
+++ b/Yukari/src/main/java/shibafu/yukari/service/PostService.java
@@ -25,6 +25,7 @@ import shibafu.yukari.entity.StatusDraft;
 import shibafu.yukari.linkage.ProviderApi;
 import shibafu.yukari.linkage.ProviderApiException;
 import shibafu.yukari.twitter.AuthUserRecord;
+import shibafu.yukari.twitter.TwitterUtil;
 import shibafu.yukari.util.BitmapUtil;
 import shibafu.yukari.util.CompatUtil;
 
@@ -302,7 +303,7 @@ public class PostService extends IntentService{
                 long inReplyToId = intent.getLongExtra(TweetActivity.EXTRA_IN_REPLY_TO, -1);
 
                 draft.setMessageTarget(targetSN);
-                draft.setInReplyTo(String.valueOf(inReplyToId));
+                draft.setInReplyTo(TwitterUtil.getUrlFromUserId(inReplyToId));
                 draft.setDirectMessage(true);
                 draft.setText(String.valueOf(voiceInput));
             } else {

--- a/Yukari/src/main/java/shibafu/yukari/twitter/TwitterApi.kt
+++ b/Yukari/src/main/java/shibafu/yukari/twitter/TwitterApi.kt
@@ -162,7 +162,10 @@ class TwitterApi : ProviderApi {
         val twitter = service.getTwitter(userRecord) ?: throw IllegalStateException("Twitterとの通信の準備に失敗しました")
         try {
             if (draft.isDirectMessage) {
-                val inReplyTo = draft.inReplyTo?.toLongOrNull() ?: throw ProviderApiException("返信先に不正な値が指定されました。")
+                val inReplyTo = TwitterUtil.getUserIdFromUrl(draft.inReplyTo)
+                if (inReplyTo == -1L) {
+                    throw ProviderApiException("返信先に不正な値が指定されました。")
+                }
                 val users = twitter.lookupUsers(inReplyTo, userRecord.NumericId)
                 val result = twitter.sendDirectMessage(inReplyTo, draft.text)
                 return TwitterMessage(result,

--- a/Yukari/src/main/java/shibafu/yukari/twitter/TwitterUtil.java
+++ b/Yukari/src/main/java/shibafu/yukari/twitter/TwitterUtil.java
@@ -1,6 +1,7 @@
 package shibafu.yukari.twitter;
 
 import android.content.Context;
+import android.net.Uri;
 import android.support.annotation.NonNull;
 import shibafu.yukari.R;
 import twitter4j.TwitterFactory;
@@ -64,5 +65,34 @@ public class TwitterUtil {
             }
         }
         return -1;
+    }
+
+    /**
+     * TwitterのUser Intent URLをパースし、IDを取得します。
+     * @param url User Intent URL (https://twitter.com/intent/user?user_id=xxxx)
+     * @return User ID, 不正なURLの場合は -1
+     */
+    public static long getUserIdFromUrl(String url) {
+        Pattern pattern = Pattern.compile("^https?://(?:www\\.)?twitter\\.com/intent/user\\?");
+        Matcher matcher = pattern.matcher(url);
+        if (matcher.find()) {
+            Uri uri = Uri.parse(url);
+            String idString = uri.getQueryParameter("user_id");
+            try {
+                return Long.valueOf(idString);
+            } catch (NumberFormatException e) {
+                return -1;
+            }
+        }
+        return -1;
+    }
+
+    /**
+     * TwitterのUser IDをUser Intent URLに変換します。
+     * @param id User ID
+     * @return User Intent URL (https://twitter.com/intent/user?user_id=xxxx)
+     */
+    public static String getUrlFromUserId(long id) {
+        return "https://twitter.com/intent/user?user_id=" + id;
     }
 }


### PR DESCRIPTION
## TODO
- [x] DM送信先IDをIntent URLとしてマイグレーション
- [x] StatusDraft#inReplyToは常にURLとして処理するように (DMの時はLong変換可能な値が入っているという前提はなくなる)
- [x] EXTRA_IN_REPLY_TOにLongのUser IDをセットしている場所を全てURLにする

## 影響
下記のケースに該当する場合、その下書きは送信不能な不正データということになる。この場合、ユーザーは下書きを破棄するしかない。
* y4a 2.0からy4aNに下書きを持ち込んでいた場合
* y4aNの今までのリリース (〜2.1.0.1853-dev) でDM下書きを保存していた場合

fix #224