### PR TITLE
UserExtrasのIDにIdenticalなURLを使用する

### DIFF
--- a/Yukari/src/main/java/shibafu/yukari/activity/StatusActivity.java
+++ b/Yukari/src/main/java/shibafu/yukari/activity/StatusActivity.java
@@ -172,7 +172,7 @@ public class StatusActivity extends ActionBarYukariBase implements StatusUI {
         tweetView.setUserExtras(getTwitterService().getUserExtras());
         tweetView.updateView();
 
-        AuthUserRecord priorityUser = getTwitterService().getPriority(status.getOriginStatus().getUser().getUrl());
+        AuthUserRecord priorityUser = getTwitterService().getPriority(status.getOriginStatus().getUser().getIdenticalUrl());
         if (priorityUser != null) {
             setUserRecord(priorityUser);
         }

--- a/Yukari/src/main/java/shibafu/yukari/entity/User.kt
+++ b/Yukari/src/main/java/shibafu/yukari/entity/User.kt
@@ -18,6 +18,14 @@ interface User : Comparable<User>, Serializable, Mention {
         get() = null
 
     /**
+     * 同一性のあるURL
+     *
+     * [url] との違いとして、こちらは内部でIDとして使用することを想定するため、アプリおよびサービスのライフサイクル内での同一性が確保されている必要がある。
+     */
+    val identicalUrl: String?
+        get() = url
+
+    /**
      * URLのHost
      *
      * ホストの判定が必要な場合に、パース負荷軽減のために参照する。

--- a/Yukari/src/main/java/shibafu/yukari/fragment/ProfileFragment.java
+++ b/Yukari/src/main/java/shibafu/yukari/fragment/ProfileFragment.java
@@ -557,7 +557,7 @@ public class ProfileFragment extends YukariBaseFragment implements FollowDialogF
 
     private int getTargetUserColor() {
         if (isTwitterServiceBound() && getTwitterService() != null) {
-            String url = TwitterUtil.getProfileUrl(loadHolder.targetUser.getScreenName());
+            String url = TwitterUtil.getUrlFromUserId(loadHolder.targetUser.getId());
             for (UserExtras userExtra : getTwitterService().getUserExtras()) {
                 if (url.equals(userExtra.getId())) {
                     return userExtra.getColor();
@@ -730,7 +730,7 @@ public class ProfileFragment extends YukariBaseFragment implements FollowDialogF
                 if (resultCode == Activity.RESULT_OK) {
                     AuthUserRecord userRecord = (AuthUserRecord) data.getSerializableExtra(AccountChooserActivity.EXTRA_SELECTED_RECORD);
                     if (loadHolder != null && loadHolder.targetUser != null && userRecord != null) {
-                        getTwitterService().setPriority(TwitterUtil.getProfileUrl(loadHolder.targetUser.getScreenName()), userRecord);
+                        getTwitterService().setPriority(TwitterUtil.getUrlFromUserId(loadHolder.targetUser.getId()), userRecord);
                         Toast.makeText(getActivity(), "優先アカウントを @" + userRecord.ScreenName + " に設定しました", Toast.LENGTH_SHORT).show();
                         updateMenuItems();
 
@@ -764,7 +764,7 @@ public class ProfileFragment extends YukariBaseFragment implements FollowDialogF
     @Override
     public void onColorPicked(int color, String tag) {
         if (isTwitterServiceBound()) {
-            getTwitterService().setColor(TwitterUtil.getProfileUrl(loadHolder.targetUser.getScreenName()), color);
+            getTwitterService().setColor(TwitterUtil.getUrlFromUserId(loadHolder.targetUser.getId()), color);
             showProfile(loadHolder);
         } else {
             //TODO: 遅延処理にすべきかなあ
@@ -786,7 +786,7 @@ public class ProfileFragment extends YukariBaseFragment implements FollowDialogF
             if (loadHolder != null && loadHolder.targetUser != null) {
                 Runnable task = () -> {
                     List<UserExtras> userExtras = getTwitterService().getUserExtras();
-                    String url = TwitterUtil.getProfileUrl(loadHolder.targetUser.getScreenName());
+                    String url = TwitterUtil.getUrlFromUserId(loadHolder.targetUser.getId());
                     Optional<UserExtras> userExtra = Stream.of(userExtras).filter(ue -> url.equals(ue.getId())).findFirst();
                     AuthUserRecord priorityAccount = userExtra.orElseGet(() -> new UserExtras(url)).getPriorityAccount();
                     if (priorityAccount != null) {
@@ -920,7 +920,7 @@ public class ProfileFragment extends YukariBaseFragment implements FollowDialogF
                 return true;
             }
             case R.id.action_unset_priority: {
-                getTwitterService().setPriority(TwitterUtil.getProfileUrl(loadHolder.targetUser.getScreenName()), null);
+                getTwitterService().setPriority(TwitterUtil.getUrlFromUserId(loadHolder.targetUser.getId()), null);
                 Toast.makeText(getActivity(), "優先アカウントを解除しました", Toast.LENGTH_SHORT).show();
 
                 user = (AuthUserRecord) getArguments().getSerializable(EXTRA_USER);

--- a/Yukari/src/main/java/shibafu/yukari/fragment/tabcontent/BookmarkListFragment.java
+++ b/Yukari/src/main/java/shibafu/yukari/fragment/tabcontent/BookmarkListFragment.java
@@ -97,7 +97,7 @@ public class BookmarkListFragment extends TweetListFragment implements Queryable
                 if (checkOwn != null) {
                     status.setOwner(checkOwn);
                 } else {
-                    String url = TwitterUtil.getProfileUrl(status.getSourceUser().getScreenName());
+                    String url = TwitterUtil.getUrlFromUserId(status.getSourceUser().getId());
                     Optional<UserExtras> first = Stream.of(userExtras).filter(ue -> url.equals(ue.getId())).findFirst();
                     if (first.isPresent() && first.get().getPriorityAccount() != null) {
                         status.setOwner(first.get().getPriorityAccount());

--- a/Yukari/src/main/java/shibafu/yukari/fragment/tabcontent/TimelineFragment.kt
+++ b/Yukari/src/main/java/shibafu/yukari/fragment/tabcontent/TimelineFragment.kt
@@ -696,7 +696,7 @@ open class TimelineFragment : ListYukariBaseFragment(), TimelineTab, TimelineObs
         // 自身の所有するStatusの場合、書き換えてはいけない
         if (!status.isOwnedStatus()) {
             // 優先アカウント設定が存在するか？
-            val userExtras = twitterService.userExtras.firstOrNull { it.id == status.originStatus.user.url }
+            val userExtras = twitterService.userExtras.firstOrNull { it.id == status.originStatus.user.identicalUrl }
             if (userExtras != null && userExtras.priorityAccount != null) {
                 status.representUser = userExtras.priorityAccount
                 if (!status.receivedUsers.contains(userExtras.priorityAccount)) {

--- a/Yukari/src/main/java/shibafu/yukari/fragment/tabcontent/TweetListFragment.java
+++ b/Yukari/src/main/java/shibafu/yukari/fragment/tabcontent/TweetListFragment.java
@@ -383,7 +383,7 @@ public abstract class TweetListFragment extends TwitterListFragment<PreformedSta
         } else if (getTwitterService() != null) {
             //優先アカウントチェック
             List<UserExtras> userExtras = getTwitterService().getUserExtras();
-            String url = TwitterUtil.getProfileUrl(status.getSourceUser().getScreenName());
+            String url = TwitterUtil.getUrlFromUserId(status.getSourceUser().getId());
             Optional<UserExtras> first = Stream.of(userExtras).filter(ue -> url.equals(ue.getId())).findFirst();
             if (first.isPresent() && first.get().getPriorityAccount() != null) {
                 status.setOwner(first.get().getPriorityAccount());

--- a/Yukari/src/main/java/shibafu/yukari/twitter/RESTLoader.java
+++ b/Yukari/src/main/java/shibafu/yukari/twitter/RESTLoader.java
@@ -65,7 +65,7 @@ public abstract class RESTLoader<P, T extends List<PreformedStatus>> extends Par
                 if (checkOwn != null) {
                     status.setOwner(checkOwn);
                 } else {
-                    String url = TwitterUtil.getProfileUrl(status.getSourceUser().getScreenName());
+                    String url = TwitterUtil.getUrlFromUserId(status.getSourceUser().getId());
                     Optional<UserExtras> first = Stream.of(userExtras).filter(ue -> url.equals(ue.getId())).findFirst();
                     if (first.isPresent() && first.get().getPriorityAccount() != null) {
                         status.setOwner(first.get().getPriorityAccount());

--- a/Yukari/src/main/java/shibafu/yukari/twitter/entity/TwitterUser.kt
+++ b/Yukari/src/main/java/shibafu/yukari/twitter/entity/TwitterUser.kt
@@ -9,6 +9,9 @@ class TwitterUser(val user: twitter4j.User) : User {
     override val url: String?
         get() = "https://twitter.com/$screenName"
 
+    override val identicalUrl: String?
+        get() = "https://twitter.com/intent/user?user_id=$id"
+
     override val host: String?
         get() = "twitter.com"
 

--- a/Yukari/src/main/java/shibafu/yukari/view/TweetView.kt
+++ b/Yukari/src/main/java/shibafu/yukari/view/TweetView.kt
@@ -58,7 +58,7 @@ class TweetView : StatusView {
         }
 
         // ユーザーカラーラベルの設定
-        val color = userExtras.firstOrNull { it.id == status.originStatus.user.url }?.color ?: Color.TRANSPARENT
+        val color = userExtras.firstOrNull { it.id == status.originStatus.user.identicalUrl }?.color ?: Color.TRANSPARENT
         ivUserColor.setBackgroundColor(color)
     }
 


### PR DESCRIPTION
UserExtrasのIDに `https://twitter.com/screen_name` を使用してしまうと、ScreenNameが変更された場合に対応付けを失ってしまう。

代わりに、Intent URL `https://twitter.com/intent/user?user_id=0` を使用するように変更する。

:warning: この変更によってUserExtrasのマイグレーションが可能になるので、そちらの対応を入れる必要もある。

refs #158 