### PR TITLE
Twitter for Androidと連携して認証する機能を削除

### DIFF
--- a/Yukari/src/main/AndroidManifest.xml
+++ b/Yukari/src/main/AndroidManifest.xml
@@ -10,7 +10,6 @@
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
-    <uses-permission android:name="com.twitter.android.permission.AUTH_APP"/>
 
     <application
         android:allowBackup="true"


### PR DESCRIPTION
動作しないという報告が多くなってきたので削除する。

~昔から利便性の代わりに問題ばっかりだったし……~