### PR TITLE
起動時に1回だけTLと投稿画面の文字サイズを設定値の80%に縮める

### DIFF
--- a/Yukari/src/main/java/shibafu/yukari/activity/BackupActivity.kt
+++ b/Yukari/src/main/java/shibafu/yukari/activity/BackupActivity.kt
@@ -220,6 +220,11 @@ class BackupActivity : ActionBarYukariBase(), SimpleAlertDialogFragment.OnDialog
                                         11 -> {
                                             val records: Map<String, Any?> = Gson().fromJson(readFile("prefs.json"), object : TypeToken<Map<String, Any?>>() {}.type)
                                             val spEdit = PreferenceManager.getDefaultSharedPreferences(applicationContext).edit()
+
+                                            // マイグレーションフラグを削除する (インポートしたデータがそれらのマイグレーションを実施済であれば、それも入っているはずなので)
+                                            spEdit.remove("pref_font_timeline__migrate_3_0_0")
+                                            spEdit.remove("pref_font_input__migrate_3_0_0")
+
                                             records.forEach {
                                                 var value = it.value
                                                 if (value is Double) {

--- a/Yukari/src/main/java/shibafu/yukari/core/YukariApplication.java
+++ b/Yukari/src/main/java/shibafu/yukari/core/YukariApplication.java
@@ -158,14 +158,14 @@ public class YukariApplication extends Application {
 
             // 文字サイズの設定
             if (sp.contains("pref_font_timeline") && !sp.getBoolean("pref_font_timeline__migrate_3_0_0", false)) {
-                int size = (int) (Integer.valueOf(sp.getString("pref_font_timeline", "14")) * 0.8);
+                int size = (int) (Integer.parseInt(sp.getString("pref_font_timeline", "14")) * 0.8);
                 edit.putString("pref_font_timeline", String.valueOf(size));
             }
             edit.putBoolean("pref_font_timeline__migrate_3_0_0", true);
 
             // 入力文字サイズの設定
             if (sp.contains("pref_font_input") && !sp.getBoolean("pref_font_input__migrate_3_0_0", false)) {
-                int size = (int) (Integer.valueOf(sp.getString("pref_font_input", "18")) * 0.8);
+                int size = (int) (Integer.parseInt(sp.getString("pref_font_input", "18")) * 0.8);
                 edit.putString("pref_font_input", String.valueOf(size));
             }
             edit.putBoolean("pref_font_input__migrate_3_0_0", true);


### PR DESCRIPTION
y4a2からの移行措置。最初からy4a3だった場合は影響を受けないが、y4aNユーザーは巻き添えを食う。

refs #244