### PR TITLE
代表アカウントの再決定アルゴリズムを再実装

### DIFF
--- a/Yukari/src/main/java/shibafu/yukari/entity/ExceptionStatus.kt
+++ b/Yukari/src/main/java/shibafu/yukari/entity/ExceptionStatus.kt
@@ -17,6 +17,7 @@ class ExceptionStatus(override val id: Long,
         override val isProtected: Boolean = false
         override val profileImageUrl: String = ""
         override val biggerProfileImageUrl: String = ""
+        override fun isMentionedTo(userRecord: AuthUserRecord): Boolean = false
     }
 
     override val text: String = exception.message ?: "例外が発生しました"

--- a/Yukari/src/main/java/shibafu/yukari/entity/ExceptionStatus.kt
+++ b/Yukari/src/main/java/shibafu/yukari/entity/ExceptionStatus.kt
@@ -28,6 +28,7 @@ class ExceptionStatus(override val id: Long,
     override val metadata: StatusPreforms = StatusPreforms()
     override val providerApiType: Int = Provider.API_SYSTEM
     override val providerHost: String = HOST
+    override var representOverrode: Boolean = false
     override var receivedUsers: MutableList<AuthUserRecord> = arrayListOf(representUser)
 
     companion object {

--- a/Yukari/src/main/java/shibafu/yukari/entity/LoadMarker.kt
+++ b/Yukari/src/main/java/shibafu/yukari/entity/LoadMarker.kt
@@ -32,6 +32,7 @@ class LoadMarker(override val id: Long,
         override val isProtected: Boolean = false
         override val profileImageUrl: String = ""
         override val biggerProfileImageUrl: String = ""
+        override fun isMentionedTo(userRecord: AuthUserRecord): Boolean = false
     }
 
     override val text: String

--- a/Yukari/src/main/java/shibafu/yukari/entity/LoadMarker.kt
+++ b/Yukari/src/main/java/shibafu/yukari/entity/LoadMarker.kt
@@ -42,6 +42,7 @@ class LoadMarker(override val id: Long,
     override var favoritesCount: Int = 0
     override var repostsCount: Int = 0
     override val metadata: StatusPreforms = StatusPreforms()
+    override var representOverrode: Boolean = false
     override var receivedUsers: MutableList<AuthUserRecord> = arrayListOf(representUser)
     override val providerHost: String = HOST
 

--- a/Yukari/src/main/java/shibafu/yukari/entity/Mention.kt
+++ b/Yukari/src/main/java/shibafu/yukari/entity/Mention.kt
@@ -1,5 +1,6 @@
 package shibafu.yukari.entity
 
+import shibafu.yukari.twitter.AuthUserRecord
 import java.io.Serializable
 
 /**
@@ -29,4 +30,9 @@ interface Mention : Serializable {
      */
     val profileImageUrl: String
         get() = ""
+
+    /**
+     * 引数で指定されたアカウントに対するメンションかどうかを判定する。
+     */
+    fun isMentionedTo(userRecord: AuthUserRecord): Boolean
 }

--- a/Yukari/src/main/java/shibafu/yukari/entity/MockStatus.kt
+++ b/Yukari/src/main/java/shibafu/yukari/entity/MockStatus.kt
@@ -15,6 +15,7 @@ open class MockStatus(override val id: Long, override var representUser: AuthUse
         override val isProtected: Boolean = false
         override val profileImageUrl: String = ""
         override val biggerProfileImageUrl: String = ""
+        override fun isMentionedTo(userRecord: AuthUserRecord): Boolean = false
     }
 
     override val text: String = ""

--- a/Yukari/src/main/java/shibafu/yukari/entity/MockStatus.kt
+++ b/Yukari/src/main/java/shibafu/yukari/entity/MockStatus.kt
@@ -26,6 +26,7 @@ open class MockStatus(override val id: Long, override var representUser: AuthUse
     override val metadata: StatusPreforms = StatusPreforms()
     override val providerApiType: Int = Provider.API_SYSTEM
     override val providerHost: String = HOST
+    override var representOverrode: Boolean = false
     override var receivedUsers: MutableList<AuthUserRecord> = arrayListOf(representUser)
 
     companion object {

--- a/Yukari/src/main/java/shibafu/yukari/entity/NotifyHistory.kt
+++ b/Yukari/src/main/java/shibafu/yukari/entity/NotifyHistory.kt
@@ -24,6 +24,11 @@ class NotifyHistory(timeAtMillis: Long, @NotifyKind val kind: Int, eventBy: User
         set(value) {
             status.representUser = value
         }
+    override var representOverrode: Boolean
+        get() = status.representOverrode
+        set(value) {
+            status.representOverrode = value
+        }
     override var receivedUsers: MutableList<AuthUserRecord>
         get() = status.receivedUsers
         set(value) {

--- a/Yukari/src/main/java/shibafu/yukari/entity/Status.kt
+++ b/Yukari/src/main/java/shibafu/yukari/entity/Status.kt
@@ -120,6 +120,11 @@ interface Status : Comparable<Status>, Serializable {
     var representUser: AuthUserRecord
 
     /**
+     * 代表受信アカウントが高優先度なアカウントでロックされているかどうか
+     */
+    var representOverrode: Boolean
+
+    /**
      * 同一のステータスを受信した全てのアカウント
      */
     var receivedUsers: MutableList<AuthUserRecord>
@@ -137,6 +142,7 @@ interface Status : Comparable<Status>, Serializable {
         userRecords.forEach { userRecord ->
             if (providerApiType == userRecord.Provider.apiType && user.url == userRecord.Url) {
                 representUser = userRecord
+                representOverrode = true
                 if (!receivedUsers.contains(userRecord)) {
                     receivedUsers.add(userRecord)
                 }

--- a/Yukari/src/main/java/shibafu/yukari/entity/Status.kt
+++ b/Yukari/src/main/java/shibafu/yukari/entity/Status.kt
@@ -230,13 +230,18 @@ interface Status : Comparable<Status>, Serializable {
             status.representOverrode = true
             status.representUser = representUser
         } else if (!representOverrode && !status.representOverrode) {
-            // TODO: メンション判定の手法
-
-            // 受信アカウントの中にプライマリアカウントがいれば、そのアカウントで上書き
-            val primary = receivedUsers.firstOrNull { it.isPrimary }
-            if (primary != null) {
-                representUser = primary
-                status.representUser = primary
+            // メンションを受けているアカウントがあれば、そのアカウントで上書き
+            val mentioned = mentions.mapNotNull { mention -> receivedUsers.firstOrNull(mention::isMentionedTo) }.firstOrNull()
+            if (mentioned != null) {
+                representUser = mentioned
+                status.representUser = mentioned
+            } else {
+                // 受信アカウントの中にプライマリアカウントがいれば、そのアカウントで上書き
+                val primary = receivedUsers.firstOrNull { it.isPrimary }
+                if (primary != null) {
+                    representUser = primary
+                    status.representUser = primary
+                }
             }
         }
 

--- a/Yukari/src/main/java/shibafu/yukari/entity/Status.kt
+++ b/Yukari/src/main/java/shibafu/yukari/entity/Status.kt
@@ -186,6 +186,10 @@ interface Status : Comparable<Status>, Serializable {
      * 同じ内容を指す、より新しい別インスタンスの情報と比較してなるべく最新かつ情報の完全性が高いインスタンスを返す
      */
     fun merge(status: Status): Status {
+        if (this === status) {
+            return this
+        }
+
         if (this != status || this.providerApiType != status.providerApiType) {
             throw IllegalArgumentException("マージは両インスタンスがEqualsかつAPI Typeが揃っていないと実行できません。this[URL=$url, API=$providerApiType] : args[URL=${status.url}, API=${status.providerApiType}]")
         }

--- a/Yukari/src/main/java/shibafu/yukari/fragment/tabcontent/TimelineFragment.kt
+++ b/Yukari/src/main/java/shibafu/yukari/fragment/tabcontent/TimelineFragment.kt
@@ -756,6 +756,7 @@ open class TimelineFragment : ListYukariBaseFragment(),
             val userExtras = twitterService.userExtras.firstOrNull { it.id == status.originStatus.user.identicalUrl }
             if (userExtras != null && userExtras.priorityAccount != null) {
                 status.representUser = userExtras.priorityAccount
+                status.representOverrode = true
                 if (!status.receivedUsers.contains(userExtras.priorityAccount)) {
                     status.receivedUsers.add(userExtras.priorityAccount)
                 }

--- a/Yukari/src/main/java/shibafu/yukari/fragment/tabcontent/TimelineFragment.kt
+++ b/Yukari/src/main/java/shibafu/yukari/fragment/tabcontent/TimelineFragment.kt
@@ -675,7 +675,6 @@ open class TimelineFragment : ListYukariBaseFragment(),
                         "timelineId" to event.timelineId
                 )
 
-                if (statuses.contains(status)) return
                 if (status !is LoadMarker && !query.evaluate(status, users, queryVariables)) return
 
                 if (event.muted) {

--- a/Yukari/src/main/java/shibafu/yukari/mastodon/entity/DonMention.kt
+++ b/Yukari/src/main/java/shibafu/yukari/mastodon/entity/DonMention.kt
@@ -1,7 +1,9 @@
 package shibafu.yukari.mastodon.entity
 
 import com.sys1yagi.mastodon4j.api.entity.Mention
+import shibafu.yukari.database.Provider
 import shibafu.yukari.mastodon.MastodonUtil
+import shibafu.yukari.twitter.AuthUserRecord
 import shibafu.yukari.entity.Mention as IMention
 
 class DonMention(mention: Mention) : IMention {
@@ -10,4 +12,12 @@ class DonMention(mention: Mention) : IMention {
     override val url: String = mention.url
 
     override val screenName: String = MastodonUtil.expandFullScreenName(mention.acct, mention.url)
+
+    override fun isMentionedTo(userRecord: AuthUserRecord): Boolean {
+        if (userRecord.Provider.apiType != Provider.API_MASTODON) {
+            return false
+        }
+
+        return userRecord.ScreenName == screenName
+    }
 }

--- a/Yukari/src/main/java/shibafu/yukari/mastodon/entity/DonStatus.kt
+++ b/Yukari/src/main/java/shibafu/yukari/mastodon/entity/DonStatus.kt
@@ -122,6 +122,10 @@ class DonStatus(val status: Status,
     }
 
     override fun merge(status: IStatus): IStatus {
+        if (this === status) {
+            return this
+        }
+
         super.merge(status)
 
         // ローカルトゥートを優先

--- a/Yukari/src/main/java/shibafu/yukari/mastodon/entity/DonStatus.kt
+++ b/Yukari/src/main/java/shibafu/yukari/mastodon/entity/DonStatus.kt
@@ -22,6 +22,8 @@ import shibafu.yukari.media2.impl.DonPicture
 import shibafu.yukari.media2.impl.DonVideo
 import shibafu.yukari.twitter.AuthUserRecord
 import shibafu.yukari.util.MorseCodec
+import shibafu.yukari.util.readBoolean
+import shibafu.yukari.util.writeBoolean
 import java.io.StringReader
 import java.util.*
 import kotlin.collections.LinkedHashSet
@@ -69,6 +71,8 @@ class DonStatus(val status: Status,
     override val providerApiType: Int = Provider.API_MASTODON
 
     override val providerHost: String = representUser.Provider.host
+
+    override var representOverrode: Boolean = false
 
     override var receivedUsers: MutableList<AuthUserRecord> = arrayListOf(representUser)
 
@@ -226,6 +230,7 @@ class DonStatus(val status: Status,
             it.writeParcelable(metadata, 0)
             it.writeInt(favoritesCount)
             it.writeInt(repostsCount)
+            it.writeBoolean(representOverrode)
             it.writeList(receivedUsers)
 
             it.writeInt(perProviderId.size())
@@ -246,6 +251,7 @@ class DonStatus(val status: Status,
                 val donStatus = DonStatus(status, representUser, metadata)
                 donStatus.favoritesCount = source.readInt()
                 donStatus.repostsCount = source.readInt()
+                donStatus.representOverrode = source.readBoolean()
                 donStatus.receivedUsers = source.readArrayList(this.javaClass.classLoader) as MutableList<AuthUserRecord>
 
                 val perProviderIdSize = source.readInt()

--- a/Yukari/src/main/java/shibafu/yukari/mastodon/entity/DonUser.kt
+++ b/Yukari/src/main/java/shibafu/yukari/mastodon/entity/DonUser.kt
@@ -5,8 +5,10 @@ import android.os.Parcel
 import android.os.Parcelable
 import com.google.gson.Gson
 import com.sys1yagi.mastodon4j.api.entity.Account
+import shibafu.yukari.database.Provider
 import shibafu.yukari.entity.User
 import shibafu.yukari.mastodon.MastodonUtil
+import shibafu.yukari.twitter.AuthUserRecord
 
 class DonUser(val account: Account?) : User, Parcelable {
     override val id: Long = account?.id ?: 0
@@ -17,6 +19,14 @@ class DonUser(val account: Account?) : User, Parcelable {
     override val isProtected: Boolean = account?.isLocked ?: false
     override val profileImageUrl: String = account?.avatar ?: ""
     override val biggerProfileImageUrl: String = account?.avatar ?: ""
+
+    override fun isMentionedTo(userRecord: AuthUserRecord): Boolean {
+        if (userRecord.Provider.apiType != Provider.API_MASTODON) {
+            return false
+        }
+
+        return userRecord.ScreenName == screenName
+    }
 
     //<editor-fold desc="Parcelable">
     override fun describeContents(): Int = 0

--- a/Yukari/src/main/java/shibafu/yukari/twitter/entity/TwitterMention.kt
+++ b/Yukari/src/main/java/shibafu/yukari/twitter/entity/TwitterMention.kt
@@ -1,6 +1,8 @@
 package shibafu.yukari.twitter.entity
 
+import shibafu.yukari.database.Provider
 import shibafu.yukari.entity.Mention
+import shibafu.yukari.twitter.AuthUserRecord
 import shibafu.yukari.twitter.TwitterUtil
 import twitter4j.UserMentionEntity
 
@@ -19,5 +21,13 @@ class TwitterMention : Mention {
         this.id = id
         this.url = TwitterUtil.getProfileUrl(screenName)
         this.screenName = screenName
+    }
+
+    override fun isMentionedTo(userRecord: AuthUserRecord): Boolean {
+        if (userRecord.Provider.apiType != Provider.API_TWITTER) {
+            return false
+        }
+
+        return userRecord.ScreenName == screenName
     }
 }

--- a/Yukari/src/main/java/shibafu/yukari/twitter/entity/TwitterMessage.kt
+++ b/Yukari/src/main/java/shibafu/yukari/twitter/entity/TwitterMessage.kt
@@ -44,6 +44,8 @@ class TwitterMessage(val message: DirectMessage,
 
     override val providerHost: String = Provider.TWITTER.host
 
+    override var representOverrode: Boolean = false
+
     override var receivedUsers: MutableList<AuthUserRecord> = arrayListOf(representUser)
 
     override fun equals(other: Any?): Boolean {

--- a/Yukari/src/main/java/shibafu/yukari/twitter/entity/TwitterStatus.kt
+++ b/Yukari/src/main/java/shibafu/yukari/twitter/entity/TwitterStatus.kt
@@ -66,6 +66,8 @@ class TwitterStatus(val status: twitter4j.Status, override var representUser: Au
 
     override val providerHost: String = Provider.TWITTER.host
 
+    override var representOverrode: Boolean = false
+
     override var receivedUsers: MutableList<AuthUserRecord> = arrayListOf(representUser)
 
     val quoteEntities: LongList

--- a/Yukari/src/main/java/shibafu/yukari/twitter/entity/TwitterUser.kt
+++ b/Yukari/src/main/java/shibafu/yukari/twitter/entity/TwitterUser.kt
@@ -1,6 +1,8 @@
 package shibafu.yukari.twitter.entity
 
+import shibafu.yukari.database.Provider
 import shibafu.yukari.entity.User
+import shibafu.yukari.twitter.AuthUserRecord
 
 class TwitterUser(val user: twitter4j.User) : User {
     override val id: Long
@@ -29,4 +31,12 @@ class TwitterUser(val user: twitter4j.User) : User {
 
     override val biggerProfileImageUrl: String
         get() = user.biggerProfileImageURLHttps
+
+    override fun isMentionedTo(userRecord: AuthUserRecord): Boolean {
+        if (userRecord.Provider.apiType != Provider.API_TWITTER) {
+            return false
+        }
+
+        return userRecord.ScreenName == screenName
+    }
 }

--- a/Yukari/src/main/java/shibafu/yukari/util/AndroidExtender.kt
+++ b/Yukari/src/main/java/shibafu/yukari/util/AndroidExtender.kt
@@ -2,6 +2,7 @@ package shibafu.yukari.util
 
 import android.content.Context
 import android.content.SharedPreferences
+import android.os.Parcel
 import android.preference.PreferenceManager
 import android.support.v4.app.Fragment
 import android.support.v4.util.SparseArrayCompat
@@ -118,4 +119,16 @@ public fun <T, R> SparseArrayCompat<T>.map(operation: (Int, T) -> R): List<R> {
 
 public operator fun <T> SparseArrayCompat<T>.set(key: Int, value: T) {
     this.put(key, value)
+}
+
+fun Parcel.writeBoolean(value: Boolean) {
+    if (value) {
+        this.writeByte(1)
+    } else {
+        this.writeByte(0)
+    }
+}
+
+fun Parcel.readBoolean(): Boolean {
+    return this.readByte() == 1.toByte()
 }


### PR DESCRIPTION
y4a3 Statusに件の判定がまるで実装されていなかったので、このPRでやっと実装した。

fix #239 