### PR TITLE
[Mastodon] mastodon4jを /api/v2/search 対応版に差し替え

### DIFF
--- a/Yukari/build.gradle
+++ b/Yukari/build.gradle
@@ -184,7 +184,7 @@ dependencies {
 
     // Mastodon
 //    implementation "com.github.sys1yagi.mastodon4j:mastodon4j:${mastodon4jVersion}"
-    implementation "com.github.shibafu528.mastodon4j:mastodon4j:0a3fbc3e7e34694d2d6844ebd4819ff57363671f"
+    implementation "com.github.shibafu528.mastodon4j:mastodon4j:cf0485c8bd20bc18b07eac92f7a6934948f3c510"
 
     // パーサ
     implementation 'com.google.code.gson:gson:2.8.1'


### PR DESCRIPTION
プロフィールページが出るようになったから多分大丈夫だと思います。

![image](https://user-images.githubusercontent.com/1352154/70386708-4c7ec800-19df-11ea-9d70-5c135b588c01.png)

refs #276