### PR TITLE
Use core library desugaring

### DIFF
--- a/Yukari/build.gradle
+++ b/Yukari/build.gradle
@@ -97,6 +97,7 @@ android {
     }
 
     compileOptions {
+        coreLibraryDesugaringEnabled true
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
     }
@@ -170,6 +171,9 @@ android {
 }
 
 dependencies {
+    // Core library desugaring
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:1.1.5'
+
     // Support Library
     implementation 'androidx.appcompat:appcompat:1.0.0'
     implementation 'androidx.cardview:cardview:1.0.0'
@@ -238,7 +242,6 @@ dependencies {
 
     // いろいろ
     implementation project(':gl-helpers')
-    implementation 'com.annimon:stream:1.0.8'
     implementation 'com.google.guava:guava:22.0-android'
     implementation 'org.eclipse.collections:eclipse-collections-api:7.1.0'
     implementation 'org.eclipse.collections:eclipse-collections:7.1.0'

--- a/Yukari/build.gradle
+++ b/Yukari/build.gradle
@@ -245,7 +245,6 @@ dependencies {
     implementation 'com.google.guava:guava:22.0-android'
     implementation 'org.eclipse.collections:eclipse-collections-api:7.1.0'
     implementation 'org.eclipse.collections:eclipse-collections:7.1.0'
-    implementation 'com.jakewharton.threetenabp:threetenabp:1.2.0'
     implementation 'com.takisoft.preferencex:preferencex:1.0.0'
     implementation fileTree(dir: './libs', includes: ['*.jar'])
 

--- a/Yukari/src/main/assets/about.html
+++ b/Yukari/src/main/assets/about.html
@@ -47,7 +47,6 @@
     <li>LeakCanary</li>
     <li>Open Sans</li>
     <li>PermissionsDispatcher</li>
-    <li>ThreeTen Android Backport</li>
     <li>twitter-text</li>
     <li>Zxing</li>
 </ul>

--- a/Yukari/src/main/java/shibafu/yukari/activity/TweetActivity.java
+++ b/Yukari/src/main/java/shibafu/yukari/activity/TweetActivity.java
@@ -56,8 +56,6 @@ import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 import android.widget.Toast;
-import com.annimon.stream.Optional;
-import com.annimon.stream.Stream;
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.sys1yagi.mastodon4j.api.entity.Status.Visibility;
@@ -120,6 +118,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -938,7 +937,7 @@ public class TweetActivity extends ActionBarYukariBase implements DraftDialogFra
         cameraTemp = state.getParcelable("cameraTemp");
         initialDraft = state.getParcelable("initialDraft");
 
-        Stream.of(state.<Uri>getParcelableArrayList("attachPictureUris")).forEach(this::attachPicture);
+        state.<Uri>getParcelableArrayList("attachPictureUris").stream().forEach(this::attachPicture);
 
         updateWritersView();
         setVisibility(state.getInt("visibility"));
@@ -1744,7 +1743,7 @@ public class TweetActivity extends ActionBarYukariBase implements DraftDialogFra
         if (getTwitterService().getmRuby() != null && !isLoadedPluggaloid) {
             Object[] result = Plugin.filtering(getTwitterService().getmRuby(), "twicca_action_edit_tweet", new HashMap());
             if (result != null && result[0] instanceof Map) {
-                Stream.of(((Map) result[0]).values()).filter(o -> o instanceof Map).forEach(o -> {
+                ((Map) result[0]).values().stream().filter(o -> o instanceof Map).forEach(o -> {
                     Map entry = (Map) o;
                     final String slug = Optional.ofNullable((String) entry.get("slug")).orElse("missing_slug");
                     final String label = Optional.ofNullable((String) entry.get("label")).orElse(slug);

--- a/Yukari/src/main/java/shibafu/yukari/core/YukariApplication.java
+++ b/Yukari/src/main/java/shibafu/yukari/core/YukariApplication.java
@@ -16,7 +16,6 @@ import androidx.annotation.RequiresApi;
 import com.google.android.gms.common.GooglePlayServicesNotAvailableException;
 import com.google.android.gms.common.GooglePlayServicesRepairableException;
 import com.google.android.gms.security.ProviderInstaller;
-import com.jakewharton.threetenabp.AndroidThreeTen;
 import com.squareup.leakcanary.LeakCanary;
 import shibafu.yukari.R;
 import shibafu.yukari.common.NotificationChannelPrefix;
@@ -47,8 +46,6 @@ public class YukariApplication extends Application {
             AlternativeHttpClientImpl.sPreferHttp2 = false;
             AlternativeHttpClientImpl.sPreferSpdy = false;
         }
-
-        AndroidThreeTen.init(this);
 
         // 通知チャンネルの作成
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {

--- a/Yukari/src/main/java/shibafu/yukari/fragment/MastodonProfileFragment.kt
+++ b/Yukari/src/main/java/shibafu/yukari/fragment/MastodonProfileFragment.kt
@@ -34,9 +34,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.async
 import kotlinx.coroutines.launch
-import org.threeten.bp.ZonedDateTime
-import org.threeten.bp.format.DateTimeFormatter
-import org.threeten.bp.temporal.ChronoUnit
 import org.xmlpull.v1.XmlPullParser
 import org.xmlpull.v1.XmlPullParserFactory
 import shibafu.yukari.R
@@ -56,6 +53,9 @@ import shibafu.yukari.util.getTwitterServiceAwait
 import shibafu.yukari.util.showToast
 import shibafu.yukari.view.ProfileButton
 import java.io.StringReader
+import java.time.ZonedDateTime
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
 import kotlin.coroutines.CoroutineContext
 import kotlin.math.roundToInt
 

--- a/Yukari/src/main/java/shibafu/yukari/fragment/ProfileFragment.java
+++ b/Yukari/src/main/java/shibafu/yukari/fragment/ProfileFragment.java
@@ -39,8 +39,6 @@ import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.TextView;
 import android.widget.Toast;
-import com.annimon.stream.Optional;
-import com.annimon.stream.Stream;
 import shibafu.yukari.R;
 import shibafu.yukari.activity.AccountChooserActivity;
 import shibafu.yukari.activity.MainActivity;
@@ -81,6 +79,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Optional;
 import java.util.Queue;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -763,7 +762,7 @@ public class ProfileFragment extends YukariBaseFragment implements FollowDialogF
                 Runnable task = () -> {
                     List<UserExtras> userExtras = getTwitterService().getUserExtras();
                     String url = TwitterUtil.getUrlFromUserId(loadHolder.targetUser.getId());
-                    Optional<UserExtras> userExtra = Stream.of(userExtras).filter(ue -> url.equals(ue.getId())).findFirst();
+                    Optional<UserExtras> userExtra = userExtras.stream().filter(ue -> url.equals(ue.getId())).findFirst();
                     AuthUserRecord priorityAccount = userExtra.orElseGet(() -> new UserExtras(url)).getPriorityAccount();
                     if (priorityAccount != null) {
                         menu.findItem(R.id.action_set_priority).setVisible(true).setTitle("優先アカウントを設定 (現在: @" + priorityAccount.ScreenName + ")");

--- a/Yukari/src/main/java/shibafu/yukari/mastodon/entity/DonStatus.kt
+++ b/Yukari/src/main/java/shibafu/yukari/mastodon/entity/DonStatus.kt
@@ -6,8 +6,6 @@ import android.util.Xml
 import com.google.gson.Gson
 import com.sys1yagi.mastodon4j.api.entity.Status
 import org.eclipse.collections.impl.map.mutable.primitive.ObjectLongHashMap
-import org.threeten.bp.DateTimeUtils
-import org.threeten.bp.ZonedDateTime
 import org.xmlpull.v1.XmlPullParser
 import org.xmlpull.v1.XmlPullParserFactory
 import shibafu.yukari.database.Provider
@@ -22,6 +20,7 @@ import shibafu.yukari.util.MorseCodec
 import shibafu.yukari.util.readBooleanCompat
 import shibafu.yukari.util.writeBooleanCompat
 import java.io.StringReader
+import java.time.ZonedDateTime
 import java.util.*
 import kotlin.collections.LinkedHashSet
 import shibafu.yukari.entity.Status as IStatus
@@ -41,7 +40,7 @@ class DonStatus(val status: Status,
     override val recipientScreenName: String
         get() = representUser.ScreenName
 
-    override val createdAt: Date = DateTimeUtils.toDate(ZonedDateTime.parse(status.createdAt).toInstant())
+    override val createdAt: Date = Date.from(ZonedDateTime.parse(status.createdAt).toInstant())
 
     override val source: String
         get() = status.application?.name ?: ""

--- a/Yukari/src/main/java/shibafu/yukari/mastodon/source/User.kt
+++ b/Yukari/src/main/java/shibafu/yukari/mastodon/source/User.kt
@@ -4,7 +4,6 @@ import com.sys1yagi.mastodon4j.MastodonClient
 import com.sys1yagi.mastodon4j.api.Pageable
 import com.sys1yagi.mastodon4j.api.method.Accounts
 import info.shibafu528.yukari.processor.filter.Source
-import org.threeten.bp.ZonedDateTime
 import shibafu.yukari.database.Provider
 import shibafu.yukari.filter.sexp.AndNode
 import shibafu.yukari.filter.sexp.ContainsNode
@@ -17,6 +16,7 @@ import shibafu.yukari.linkage.RestQuery
 import shibafu.yukari.linkage.RestQueryException
 import shibafu.yukari.mastodon.MastodonRestQuery
 import shibafu.yukari.database.AuthUserRecord
+import java.time.ZonedDateTime
 
 /**
  * User Timeline

--- a/Yukari/src/main/java/shibafu/yukari/service/CacheCleanerService.java
+++ b/Yukari/src/main/java/shibafu/yukari/service/CacheCleanerService.java
@@ -10,8 +10,6 @@ import androidx.annotation.NonNull;
 import androidx.core.app.JobIntentService;
 import android.text.format.DateUtils;
 import android.util.Log;
-import com.annimon.stream.Collectors;
-import com.annimon.stream.Stream;
 import shibafu.yukari.common.JobSchedulerId;
 import shibafu.yukari.common.bitmapcache.BitmapCache;
 import shibafu.yukari.database.CentralDatabase;
@@ -22,6 +20,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Created by shibafu on 14/03/04.
@@ -130,8 +129,9 @@ public class CacheCleanerService extends JobIntentService {
         List<String> usingUris = new ArrayList<>();
         CentralDatabase db = new CentralDatabase(getApplicationContext()).open();
         try {
-            usingUris = Stream.of(db.getDrafts())
-                    .flatMap(draft -> Stream.of(draft.getAttachPictures()))
+            usingUris = db.getDrafts()
+                    .stream()
+                    .flatMap(draft -> draft.getAttachPictures().stream())
                     .map(Uri::toString)
                     .distinct()
                     .filter(uri -> uri.contains(attachesDirUri))


### PR DESCRIPTION
fix #297 

AGPのCore library desugaringを有効化。

これによって不要となったLightweight Streaming APIとThreeTenABPを依存関係から削除し、Java 8標準ライブラリAPIを呼び出すように変更。

機械的に書き換えたので変な場所はあるかも。