### PR TITLE
DonStatusに最初のrepresentUserの情報を別に残して、デシリアライズ時の問題を回避する

### DIFF
--- a/Yukari/src/main/java/shibafu/yukari/activity/StatusActivity.java
+++ b/Yukari/src/main/java/shibafu/yukari/activity/StatusActivity.java
@@ -91,6 +91,10 @@ public class StatusActivity extends ActionBarYukariBase implements StatusUI {
 
         Intent args = getIntent();
         status = (Status) args.getSerializableExtra(EXTRA_STATUS);
+        if (status instanceof DonStatus) {
+            ((DonStatus) status).checkProviderHostMismatching();
+        }
+
         if (savedInstanceState != null) {
             user = (AuthUserRecord) savedInstanceState.getSerializable(EXTRA_USER);
         } else {

--- a/Yukari/src/main/java/shibafu/yukari/mastodon/MastodonApi.kt
+++ b/Yukari/src/main/java/shibafu/yukari/mastodon/MastodonApi.kt
@@ -232,6 +232,7 @@ class MastodonApi : ProviderApi {
      */
     @Throws(Mastodon4jRequestException::class)
     private fun resolveLocalId(userRecord: AuthUserRecord, status: DonStatus): Long? {
+        status.checkProviderHostMismatching()
         if (status.providerHost == userRecord.Provider.host) {
             return status.id
         }

--- a/Yukari/src/main/java/shibafu/yukari/mastodon/entity/DonStatus.kt
+++ b/Yukari/src/main/java/shibafu/yukari/mastodon/entity/DonStatus.kt
@@ -145,15 +145,12 @@ class DonStatus(val status: Status,
         if (status is DonStatus) {
             if (!this.isLocal && status.isLocal) {
                 status.perProviderId.putAll(perProviderId)
-                status.checkProviderHostMismatching()
                 return status
             } else {
                 perProviderId.putAll(status.perProviderId)
-                checkProviderHostMismatching()
                 return this
             }
         } else {
-            checkProviderHostMismatching()
             return this
         }
     }
@@ -304,5 +301,5 @@ class DonStatus(val status: Status,
     }
     //</editor-fold>
 
-    class ProviderHostMismatchedException(expected: String, actual: String) : RuntimeException("provider host mismatched!! expected = $expected, actual = $actual")
+    class ProviderHostMismatchedException(expected: String, actual: String) : RuntimeException("[BUG] provider host mismatched!! expected = $expected, actual = $actual")
 }

--- a/Yukari/src/main/java/shibafu/yukari/mastodon/entity/DonStatus.kt
+++ b/Yukari/src/main/java/shibafu/yukari/mastodon/entity/DonStatus.kt
@@ -140,12 +140,15 @@ class DonStatus(val status: Status,
         if (status is DonStatus) {
             if (!this.isLocal && status.isLocal) {
                 status.perProviderId.putAll(perProviderId)
+                status.checkProviderHostMismatching()
                 return status
             } else {
                 perProviderId.putAll(status.perProviderId)
+                checkProviderHostMismatching()
                 return this
             }
         } else {
+            checkProviderHostMismatching()
             return this
         }
     }
@@ -156,6 +159,14 @@ class DonStatus(val status: Status,
             inReplyTo[Provider.API_MASTODON, key] = value.toString()
         }
         return inReplyTo
+    }
+
+    fun checkProviderHostMismatching() {
+        val localId = perProviderId[providerHost]
+        if (id != localId) {
+            val expected = perProviderId.keyValuesView().first { pair -> pair.two == status.id }
+            throw ProviderHostMismatchedException(expected.one, providerHost)
+        }
     }
 
     init {
@@ -284,4 +295,6 @@ class DonStatus(val status: Status,
         }
     }
     //</editor-fold>
+
+    class ProviderHostMismatchedException(expected: String, actual: String) : RuntimeException("provider host mismatched!! expected = $expected, actual = $actual")
 }

--- a/Yukari/src/main/java/shibafu/yukari/mastodon/entity/DonStatus.kt
+++ b/Yukari/src/main/java/shibafu/yukari/mastodon/entity/DonStatus.kt
@@ -83,6 +83,11 @@ class DonStatus(val status: Status,
     var perProviderId: ObjectLongHashMap<String> = ObjectLongHashMap.newWithKeysValues(representUser.Provider.host, status.id)
         private set
 
+    /**
+     * この [DonStatus] オブジェクトを作成した時点の受信アカウント。
+     */
+    private val firstReceiverUser = representUser
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (other !is DonStatus) return false
@@ -249,6 +254,7 @@ class DonStatus(val status: Status,
     override fun writeToParcel(dest: Parcel?, flags: Int) {
         dest?.let {
             it.writeString(Gson().toJson(status))
+            it.writeSerializable(firstReceiverUser)
             it.writeSerializable(representUser)
             it.writeParcelable(metadata, 0)
             it.writeInt(favoritesCount)
@@ -269,9 +275,11 @@ class DonStatus(val status: Status,
             override fun createFromParcel(source: Parcel?): DonStatus {
                 source!!
                 val status = Gson().fromJson(source.readString(), Status::class.java)
+                val firstReceiverUser = source.readSerializable() as AuthUserRecord
                 val representUser = source.readSerializable() as AuthUserRecord
                 val metadata = source.readParcelable<StatusPreforms>(this.javaClass.classLoader)!!
-                val donStatus = DonStatus(status, representUser, metadata)
+                val donStatus = DonStatus(status, firstReceiverUser, metadata)
+                donStatus.representUser = representUser
                 donStatus.favoritesCount = source.readInt()
                 donStatus.repostsCount = source.readInt()
                 donStatus.representOverrode = source.readBooleanCompat()


### PR DESCRIPTION
fix #299 

DonStatusのコンストラクタで渡すrepresentUserは、同じく渡した mastodon4j.api.entity.Status を受信したサーバーのアカウントであることが暗黙に仮定されている。

そのため、マージ処理などによってrepresentUserが別のアカウントに変化した状態でそのままシリアライズ・デシリアライズを行うと、その仮定が破れてしまう。

対策として、プライベートフィールドに最初のrepresentUserの参照を複製しておいて、Parcelableのデシリアライズ時に改めてコンストラクタを呼ぶ際にはその情報を使う。インスタンス生成が完了した後、シリアライズ時点のrepresentUserに置き換える。