### PR TITLE
設定JSONからのインポート時、数値データは可能な限りLongとしてパースされるようにする

### DIFF
--- a/Yukari/build.gradle
+++ b/Yukari/build.gradle
@@ -205,7 +205,7 @@ dependencies {
     implementation "com.github.shibafu528.mastodon4j:mastodon4j:${mastodon4jVersion}"
 
     // パーサ
-    implementation 'com.google.code.gson:gson:2.8.1'
+    implementation 'com.google.code.gson:gson:2.9.0'
     implementation 'org.jsoup:jsoup:1.8.3'
     implementation 'com.google.zxing:javase:3.2.1', {
         exclude group: 'com.beust', module: 'jcommander'

--- a/Yukari/src/main/java/shibafu/yukari/activity/BookmarkRepairActivity.java
+++ b/Yukari/src/main/java/shibafu/yukari/activity/BookmarkRepairActivity.java
@@ -1,7 +1,9 @@
 package shibafu.yukari.activity;
 
+import android.annotation.SuppressLint;
 import android.database.Cursor;
 import android.os.Bundle;
+import android.util.Log;
 import android.widget.Toast;
 import shibafu.yukari.activity.base.ActionBarYukariBase;
 import shibafu.yukari.common.async.ParallelAsyncTask;
@@ -13,8 +15,12 @@ import shibafu.yukari.twitter.entity.TwitterStatus;
 import twitter4j.Twitter;
 import twitter4j.TwitterException;
 
+import java.lang.ref.WeakReference;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 
 /**
  * Created by shibafu on 15/03/31.
@@ -37,80 +43,108 @@ public class BookmarkRepairActivity extends ActionBarYukariBase {
 
     @Override
     public void onServiceConnected() {
-        ParallelAsyncTask<Void, Integer, Integer[]> task = new ParallelAsyncTask<Void, Integer, Integer[]>() {
-            @Override
-            protected void onProgressUpdate(Integer... values) {
-                super.onProgressUpdate(values);
-                binding.tvProgress.setText(String.format("%d 破損していたブックマーク\n%d 修復成功\n%d エラー", values[0], values[1], values[2]));
-            }
-
-            @Override
-            protected Integer[] doInBackground(Void... params) {
-                int processedCount = 0;
-                int repairCount = 0;
-                int failedCount = 0;
-                List<AuthUserRecord> userRecords = getTwitterService().getUsers();
-                CentralDatabase database = getTwitterService().getDatabase();
-                List<Long> aliveIDs = new ArrayList<>();
-                for (Bookmark aliveBookmark : database.getBookmarks()) {
-                    aliveIDs.add(aliveBookmark.getId());
-                }
-                Cursor cursor = database.rawQuery("select * from " + CentralDatabase.TABLE_BOOKMARKS, null);
-                try {
-                    if (cursor.moveToFirst()) {
-                        do {
-                            publishProgress(processedCount, repairCount, failedCount);
-                            long id = cursor.getLong(cursor.getColumnIndex(CentralDatabase.COL_BOOKMARKS_ID));
-                            if (aliveIDs.contains(id)) {
-                                continue;
-                            }
-                            ++processedCount;
-
-                            long receiverId = cursor.getLong(cursor.getColumnIndex(CentralDatabase.COL_BOOKMARKS_RECEIVER_ID));
-                            AuthUserRecord userRecord = null;
-                            for (AuthUserRecord record : userRecords) {
-                                if (record.InternalId == receiverId) {
-                                    userRecord = record;
-                                }
-                            }
-                            if (userRecord != null) {
-                                Twitter twitter = getTwitterService().getTwitter(userRecord);
-                                if (twitter == null) {
-                                    ++failedCount;
-                                    continue;
-                                }
-                                try {
-                                    Bookmark bookmark = new Bookmark(new TwitterStatus(twitter.showStatus(id), userRecord));
-                                    database.updateRecord(bookmark);
-                                    ++repairCount;
-                                } catch (TwitterException e) {
-                                    e.printStackTrace();
-                                    ++failedCount;
-                                }
-                            } else {
-                                ++failedCount;
-                            }
-                        } while (cursor.moveToNext());
-                    }
-                } finally {
-                    cursor.close();
-                }
-                return new Integer[]{processedCount, repairCount, failedCount};
-            }
-
-            @Override
-            protected void onPostExecute(Integer[] values) {
-                super.onPostExecute(values);
-                Toast.makeText(getApplicationContext(),
-                        String.format("修復が終了しました\n========\n%d 破損していたブックマーク\n%d 修復成功\n%d エラー",
-                                values[0], values[1], values[2]),
-                        Toast.LENGTH_LONG).show();
-                finish();
-            }
-        };
-        task.executeParallel();
+        new RepairAsyncTask(this).executeParallel();
     }
 
     @Override
     public void onServiceDisconnected() {}
+
+    private static class RepairAsyncTask extends ParallelAsyncTask<Void, Integer, Integer[]> {
+        @SuppressLint("StaticFieldLeak")
+        private final BookmarkRepairActivity activity;
+
+        public RepairAsyncTask(BookmarkRepairActivity activity) {
+            this.activity = activity;
+        }
+
+        @Override
+        protected void onProgressUpdate(Integer... values) {
+            super.onProgressUpdate(values);
+            activity.binding.tvProgress.setText(String.format("%d 破損していたブックマーク\n%d 修復成功\n%d エラー", values[0], values[1], values[2]));
+        }
+
+        @Override
+        protected Integer[] doInBackground(Void... params) {
+            int processedCount = 0;
+            int repairCount = 0;
+            int failedCount = 0;
+            List<AuthUserRecord> userRecords = activity.getTwitterService().getUsers();
+            CentralDatabase database = activity.getTwitterService().getDatabase();
+            List<Long> healthyIds = new ArrayList<>(); // 問題ないレコードのID
+            Map<Long, Long> mismatchedStatusIdByDatabaseId = new HashMap<>(); // DB上のIDとデシリアライズしたStatusのIDが合わないもの
+            for (Bookmark aliveBookmark : database.getBookmarks()) {
+                long idInDatabase = aliveBookmark.getIdInDatabase();
+                long actualStatusId = aliveBookmark.getId();
+                if (actualStatusId == idInDatabase) {
+                    healthyIds.add(idInDatabase);
+                } else {
+                    mismatchedStatusIdByDatabaseId.put(idInDatabase, actualStatusId);
+                }
+            }
+            Cursor cursor = database.rawQuery("select * from " + CentralDatabase.TABLE_BOOKMARKS, null);
+            try {
+                if (cursor.moveToFirst()) {
+                    do {
+                        publishProgress(processedCount, repairCount, failedCount);
+                        long id = cursor.getLong(cursor.getColumnIndexOrThrow(CentralDatabase.COL_BOOKMARKS_ID));
+                        if (healthyIds.contains(id)) {
+                            Log.d("BookmarkRepairActivity", String.format(Locale.US, "%d: healthy", id));
+                            continue;
+                        }
+                        if (mismatchedStatusIdByDatabaseId.containsKey(id)) {
+                            Log.d("BookmarkRepairActivity", String.format(Locale.US, "%d: unhealthy (id mismatch)", id));
+                        } else {
+                            Log.d("BookmarkRepairActivity", String.format(Locale.US, "%d: unhealthy (deserialize failed)", id));
+                        }
+                        ++processedCount;
+
+                        long receiverId = cursor.getLong(cursor.getColumnIndexOrThrow(CentralDatabase.COL_BOOKMARKS_RECEIVER_ID));
+                        AuthUserRecord userRecord = null;
+                        for (AuthUserRecord record : userRecords) {
+                            if (record.InternalId == receiverId) {
+                                userRecord = record;
+                            }
+                        }
+                        if (userRecord == null) {
+                            Log.d("BookmarkRepairActivity", String.format(Locale.US, "%d: receiver user not found", id));
+                            ++failedCount;
+                            continue;
+                        }
+
+                        Twitter twitter = activity.getTwitterService().getTwitter(userRecord);
+                        if (twitter == null) {
+                            Log.d("BookmarkRepairActivity", String.format(Locale.US, "%d: failed to initialize twitter api client", id));
+                            ++failedCount;
+                            continue;
+                        }
+                        try {
+                            long statusId = mismatchedStatusIdByDatabaseId.getOrDefault(id, id);
+                            Bookmark bookmark = new Bookmark(new TwitterStatus(twitter.showStatus(statusId), userRecord));
+                            if (mismatchedStatusIdByDatabaseId.containsKey(id)) {
+                                database.rawQuery("DELETE FROM " + CentralDatabase.TABLE_BOOKMARKS + " WHERE " + CentralDatabase.COL_BOOKMARKS_ID + " = " + id, null).moveToFirst();
+                            }
+                            database.updateRecord(bookmark);
+                            ++repairCount;
+                        } catch (TwitterException e) {
+                            e.printStackTrace();
+                            ++failedCount;
+                        }
+                    } while (cursor.moveToNext());
+                }
+            } finally {
+                cursor.close();
+            }
+            return new Integer[]{processedCount, repairCount, failedCount};
+        }
+
+        @Override
+        protected void onPostExecute(Integer[] values) {
+            super.onPostExecute(values);
+            Toast.makeText(activity.getApplicationContext(),
+                    String.format("修復が終了しました\n========\n%d 破損していたブックマーク\n%d 修復成功\n%d エラー",
+                            values[0], values[1], values[2]),
+                    Toast.LENGTH_LONG).show();
+            activity.finish();
+        }
+    }
 }

--- a/Yukari/src/main/java/shibafu/yukari/database/Bookmark.kt
+++ b/Yukari/src/main/java/shibafu/yukari/database/Bookmark.kt
@@ -12,12 +12,20 @@ import java.util.*
 
 @DBTable(CentralDatabase.TABLE_BOOKMARKS)
 class Bookmark private constructor(val twitterStatus: TwitterStatus, private val saveDate: Date) : Status by twitterStatus, DBRecord {
+    var idInDatabase: Long? = null
+
     constructor(status: TwitterStatus) : this(status, Date())
 
     constructor(cursor: Cursor) : this(
             byteArrayToStatus(cursor.getBlob(cursor.getColumnIndex(CentralDatabase.COL_BOOKMARKS_BLOB)), AuthUserRecord(cursor)),
             Date(cursor.getLong(cursor.getColumnIndex(CentralDatabase.COL_BOOKMARKS_SAVE_DATE)))
-    )
+    ) {
+        var idColumn = cursor.getColumnIndex("_id_b")
+        if (idColumn == -1) {
+            idColumn = cursor.getColumnIndexOrThrow(CentralDatabase.COL_BOOKMARKS_ID)
+        }
+        idInDatabase = cursor.getLong(idColumn)
+    }
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true

--- a/Yukari/src/main/java/shibafu/yukari/database/CentralDatabase.java
+++ b/Yukari/src/main/java/shibafu/yukari/database/CentralDatabase.java
@@ -1214,13 +1214,13 @@ public class CentralDatabase {
                 } else if (entry.getValue() instanceof String) {
                     values.put(entry.getKey(), (String) entry.getValue());
                 } else if (entry.getValue() instanceof List) {
-                    // ここではbyte[]になりそこねたList<Double>が来ることのみを想定している
+                    // ここではbyte[]になりそこねたList<Long>が来ることのみを想定している
 
                     List byteList = (List) entry.getValue();
                     byte[] buf = new byte[byteList.size()];
 
                     for (int i = 0; i < buf.length; i++) {
-                        double v = (double) byteList.get(i);
+                        long v = (long) byteList.get(i);
                         buf[i] = (byte) v;
                     }
 

--- a/Yukari/src/main/java/shibafu/yukari/export/ConfigFileUtility.kt
+++ b/Yukari/src/main/java/shibafu/yukari/export/ConfigFileUtility.kt
@@ -1,6 +1,8 @@
 package shibafu.yukari.export
 
 import com.google.gson.Gson
+import com.google.gson.GsonBuilder
+import com.google.gson.ToNumberPolicy
 import com.google.gson.reflect.TypeToken
 import com.google.gson.stream.JsonWriter
 import shibafu.yukari.common.TabInfo
@@ -156,7 +158,7 @@ object ConfigFileUtility {
         @Suppress("UNCHECKED_CAST")
         val filter = filters[clazz] as? ConfigFileMigrator<T> ?: throw IllegalArgumentException("invalid argument 'clazz' : $clazz")
 
-        val decodedJson = Gson().fromJson(json, Map::class.java)
+        val decodedJson = newGson().fromJson(json, Map::class.java)
         if (!decodedJson.containsKey("version")) {
             throw InvalidJsonException("invalid json : not contains key 'version'")
         }
@@ -181,6 +183,11 @@ object ConfigFileUtility {
 
         throw InvalidJsonException("invalid json : invalid format key '$className'")
     }
+
+    private fun newGson(): Gson = GsonBuilder()
+            .setObjectToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
+            .setNumberToNumberStrategy(ToNumberPolicy.LONG_OR_DOUBLE)
+            .create()
 }
 
 /**

--- a/Yukari/src/main/java/shibafu/yukari/export/Migrator.kt
+++ b/Yukari/src/main/java/shibafu/yukari/export/Migrator.kt
@@ -43,7 +43,7 @@ class TabInfoMigrator : ConfigFileMigrator<TabInfo> {
         // Version 2
         migrateTo(2) { config, db ->
             // BindAccountIdをTwitter IDからInternal Account IDに変換
-            findInternalAccountId(db, (config["BindAccountId"] as Double).toLong())?.let {
+            findInternalAccountId(db, (config["BindAccountId"] as Long))?.let {
                 config["BindAccountId"] = it
             }
         }
@@ -72,7 +72,7 @@ class UserExtrasMigrator : ConfigFileMigrator<UserExtras> {
             config["_id"] = "https://twitter.com/intent/user?user_id=${config["_id"]}"
 
             // PriorityAccountIdをTwitter IDからInternal Account IDに変換
-            findInternalAccountId(db, (config["PriorityAccountId"] as Double).toLong())?.let {
+            findInternalAccountId(db, (config["PriorityAccountId"] as Long))?.let {
                 config["PriorityAccountId"] = it
             }
         }
@@ -86,7 +86,7 @@ class BookmarkMigrator : ConfigFileMigrator<Bookmark.SerializeEntity> {
         // Version 2
         migrateTo(2) { config, db ->
             // ReceiverIdをTwitter IDからInternal Account IDに変換
-            findInternalAccountId(db, (config["ReceiverId"] as Double).toLong())?.let {
+            findInternalAccountId(db, (config["ReceiverId"] as Long).toLong())?.let {
                 config["ReceiverId"] = it
             }
         }
@@ -102,12 +102,12 @@ class StatusDraftMigrator : ConfigFileMigrator<StatusDraft> {
         // Version 2
         migrateTo(2) { config, db ->
             // WriterIdをTwitter IDからInternal Account IDに変換
-            findInternalAccountId(db, (config["WriterId"] as Double).toLong())?.let {
+            findInternalAccountId(db, config["WriterId"] as Long)?.let {
                 config["WriterId"] = it
             }
 
             val isDirectMessage = (config["IsDirectMessage"] ?: "0").toString()
-            val inReplyToId = (config["InReplyTo"] as Double).toLong()
+            val inReplyToId = config["InReplyTo"] as Long
 
             // InReplyToをURLに変換
             if (inReplyToId <= 0) {


### PR DESCRIPTION
fix #240

設定JSONからのインポート時、今までずっと数値データは全てDoubleとして解釈されていた。そのため、誤差が発生しデータ不整合を起こすことがあった。

Gson 2.8.9からはこの問題を可能な範囲で回避する機能が実装されたため、これを使って問題を回避する。

ついでに、ブックマークはIDが二重持ちになっている関係で不整合を直せる可能性があるので、既存の機能に修復プログラムを追加した。