### PR TITLE
通知設定内から、対応する通知チャンネルごとの設定画面を直接開くようにする

### DIFF
--- a/Yukari/src/main/java/shibafu/yukari/activity/ConfigActivity.java
+++ b/Yukari/src/main/java/shibafu/yukari/activity/ConfigActivity.java
@@ -228,28 +228,6 @@ public class ConfigActivity extends ActionBarYukariBase {
                             return false;
                         });
 
-                        Preference prefNotifSystemConfig = findPreference("pref_notif_system_config");
-                        prefNotifSystemConfig.setEnabled(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O);
-                        prefNotifSystemConfig.setOnPreferenceClickListener(preference -> {
-                            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                                try {
-                                    // EMUI 8.xなど、正攻法で呼び出すと通知音のカスタマイズが行えない
-                                    // ベンダーオリジナルのActivityが起動されることがある。
-                                    // そういうのは嫌なので、素のAndroidの設定画面を指名して呼び出す。
-                                    Intent intent = new Intent(Settings.ACTION_CHANNEL_NOTIFICATION_SETTINGS);
-                                    intent.setClassName("com.android.settings", "com.android.settings.Settings$AppNotificationSettingsActivity");
-                                    intent.putExtra(Settings.EXTRA_APP_PACKAGE, getContext().getPackageName());
-                                    startActivity(intent);
-                                } catch (ActivityNotFoundException e) {
-                                    // このブロックをわざわざ用意する意味はないかもしれない、とりあえず正攻法での呼出を書いただけ
-                                    Intent intent = new Intent(Settings.ACTION_CHANNEL_NOTIFICATION_SETTINGS);
-                                    intent.putExtra(Settings.EXTRA_APP_PACKAGE, getContext().getPackageName());
-                                    startActivity(intent);
-                                }
-                            }
-                            return true;
-                        });
-
                         findPreference("pref_notif_per_account_channel").setEnabled(Build.VERSION.SDK_INT >= Build.VERSION_CODES.O);
                         break;
 

--- a/Yukari/src/main/res/xml/pref_notify.xml
+++ b/Yukari/src/main/res/xml/pref_notify.xml
@@ -32,13 +32,9 @@
             android:defaultValue="true"/>
     </PreferenceCategory>
     <PreferenceCategory android:title="Android 8.0以降向けの設定">
-        <Preference
-            android:key="pref_notif_system_config"
-            android:title="システムの通知設定を開く"
-            android:summary="Android 8.0以降ではシステムの通知設定からカスタマイズできます。"/>
         <CheckBoxPreference
             android:key="pref_notif_per_account_channel"
             android:title="アカウント別の通知設定を使う"
-            android:summary="システムの通知設定の項目を、アカウント別に分割します。\nアカウントごとに細かな設定を行えるようになります。\n(※Android 8.0以上のみ有効)"/>
+            android:summary="システムの通知設定の項目を、アカウント別に分割します。\nアカウントごとに細かな設定を行えるようになります。"/>
     </PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
fix #315 

Pixel 6のAndroid 13 ROMで設定画面が開けなくなったことに伴う対応。`EXTRA_CHANNEL_ID` はmustとされているため、それに準拠する。

「アカウント別の通知設定を使う」が有効な場合はアカウント選択画面を表示して、指定されたアカウントに対応する通知チャンネルの画面を開くようにしている。