### PR TITLE
[Mastodon] listソースに対応

### DIFF
--- a/Yukari/build.gradle
+++ b/Yukari/build.gradle
@@ -57,7 +57,7 @@ class GitUtil {
 ext {
     playServicesVersion = '17.6.0'
     twitter4jVersion = '4.0.7'
-    mastodon4jVersion = '43b77f366515641a4569c2cfffef57301259c5a0'
+    mastodon4jVersion = '087b09001e99942c3423bfd6f4641c8a3a5560ce'
     exvoiceVersion = '20220503.124509'
 
     y4aVersionMajor = 3

--- a/Yukari/src/main/java/shibafu/yukari/mastodon/source/ListSource.kt
+++ b/Yukari/src/main/java/shibafu/yukari/mastodon/source/ListSource.kt
@@ -1,0 +1,32 @@
+package shibafu.yukari.mastodon.source
+
+import com.sys1yagi.mastodon4j.api.method.Timelines
+import info.shibafu528.yukari.processor.filter.Source
+import shibafu.yukari.database.Provider
+import shibafu.yukari.filter.sexp.SNode
+import shibafu.yukari.filter.sexp.ValueNode
+import shibafu.yukari.database.AuthUserRecord
+import shibafu.yukari.filter.source.FilterSource
+import shibafu.yukari.linkage.RestQueryException
+import shibafu.yukari.mastodon.MastodonRestQuery
+
+/**
+ * 指定されたアカウントのListタイムラインを対象とする抽出ソースです。
+ *
+ * Created by yufushiro on 23/02/13.
+ */
+@Source(apiType = Provider.API_MASTODON, slug = "list")
+data class ListSource(override val sourceAccount: AuthUserRecord, val target: String) : FilterSource {
+    private val listId: Long by lazy {
+        val (_, idStr) = target.split("/")
+        idStr.toLongOrNull() ?: throw RestQueryException(sourceAccount, InvalidListIdException(target))
+    }
+
+    override fun getRestQuery() = MastodonRestQuery { client, range ->
+        Timelines(client).getList(this.listId, range = range).execute()
+    }
+
+    override fun getStreamFilter(): SNode = ValueNode(false)
+
+    class InvalidListIdException(target: String) : Exception("リストIDは数値で指定してください: $target")
+}


### PR DESCRIPTION
filter の `list:` ソースで Mastodon のリスト ID を指定できるようにしました

---

- shibafu528/mastodon4j#1 に依存しています
- Twitter の list ソースとの差異について
    - スラッシュ区切りで1番目に指定するユーザ名は、他のユーザが作成したリストを閲覧する方法が存在しないため常に無視しています
    - 2番目に指定するリスト名は、Mastodon のリストには slug に対応する記法が存在しないため常に数値（リスト ID）として解釈しています
- クラス名は `kotlin.collections.List` と識別子が衝突してエラーになったため ListSource としました
- Kotlin は書き慣れていないので書き方が良くない等の指摘でも遠慮なくお願いします