### PR TITLE
ネットワークのトラブルシューティング用オプションの廃止

### DIFF
--- a/Yukari/src/main/java/shibafu/yukari/core/App.kt
+++ b/Yukari/src/main/java/shibafu/yukari/core/App.kt
@@ -96,7 +96,6 @@ class App : Application(), TimelineHubProvider, ApiCollectionProvider, TwitterPr
         super.onCreate()
 
         installSecurityProvider()
-        applyNetworkPreferences()
 
         // 通知チャンネルの作成
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
@@ -159,14 +158,6 @@ class App : Application(), TimelineHubProvider, ApiCollectionProvider, TwitterPr
             ProviderInstaller.installIfNeeded(this)
         } catch (ignore: GooglePlayServicesRepairableException) {
         } catch (ignore: GooglePlayServicesNotAvailableException) {
-        }
-    }
-
-    private fun applyNetworkPreferences() {
-        val sp = PreferenceManager.getDefaultSharedPreferences(this)
-        if (sp.getBoolean("pref_disable_ipv6", false)) {
-            System.setProperty("java.net.preferIPv4Stack", "true")
-            System.setProperty("java.net.preferIPv6Addresses", "false")
         }
     }
 

--- a/Yukari/src/main/java/shibafu/yukari/core/App.kt
+++ b/Yukari/src/main/java/shibafu/yukari/core/App.kt
@@ -33,7 +33,6 @@ import shibafu.yukari.mastodon.MastodonApi
 import shibafu.yukari.twitter.TwitterApi
 import shibafu.yukari.twitter.TwitterProvider
 import shibafu.yukari.util.CompatUtil
-import twitter4j.AlternativeHttpClientImpl
 
 /**
  * Created by shibafu on 2015/08/29.
@@ -168,10 +167,6 @@ class App : Application(), TimelineHubProvider, ApiCollectionProvider, TwitterPr
         if (sp.getBoolean("pref_disable_ipv6", false)) {
             System.setProperty("java.net.preferIPv4Stack", "true")
             System.setProperty("java.net.preferIPv6Addresses", "false")
-        }
-        if (sp.getBoolean("pref_force_http1", false)) {
-            AlternativeHttpClientImpl.sPreferHttp2 = false
-            AlternativeHttpClientImpl.sPreferSpdy = false
         }
     }
 

--- a/Yukari/src/main/java/shibafu/yukari/mastodon/MastodonApi.kt
+++ b/Yukari/src/main/java/shibafu/yukari/mastodon/MastodonApi.kt
@@ -28,7 +28,6 @@ import shibafu.yukari.linkage.ProviderApiException
 import shibafu.yukari.linkage.TimelineHub
 import shibafu.yukari.mastodon.api.ReportsEx
 import shibafu.yukari.mastodon.entity.DonStatus
-import shibafu.yukari.util.defaultSharedPreferences
 import java.io.File
 import java.io.IOException
 
@@ -51,9 +50,6 @@ class MastodonApi : ProviderApi {
 
     fun getApiClient(instanceName: String, accessToken: String?): MastodonClient {
         val okHttpBuilder = OkHttpClient.Builder().addInterceptor(UserAgentInterceptor(context))
-        if (context.defaultSharedPreferences.getBoolean("pref_force_http1", false)) {
-            okHttpBuilder.protocols(listOf(Protocol.HTTP_1_1))
-        }
         var builder = MastodonClient.Builder(instanceName, okHttpBuilder, Gson())
         if (accessToken != null && accessToken.isNotEmpty()) {
             builder = builder.accessToken(accessToken).useStreamingApi()

--- a/Yukari/src/main/res/xml/pref_expert.xml
+++ b/Yukari/src/main/res/xml/pref_expert.xml
@@ -73,10 +73,6 @@
             android:title="TLダブルクリックの防止"
             android:summary="投稿行クリック〜詳細表示までのラグ発生中にダブルクリックを起こさないようにしてみます\n運が悪いと一旦バックグラウンドに行かないとTLクリックできなくなるかも"/>
         <CheckBoxPreference
-            android:key="pref_force_http1"
-            android:title="http1.1を優先使用"
-            android:summary="高速なプロトコルを使用せず、旧来のプロトコルで通信が行われるようにします(※要再起動)"/>
-        <CheckBoxPreference
             android:key="pref_disable_ipv6"
             android:title="IPv6を無効化"
             android:summary="IPv6通信を無効化し、IPv4通信が優先されるようにします(※要再起動)"/>

--- a/Yukari/src/main/res/xml/pref_expert.xml
+++ b/Yukari/src/main/res/xml/pref_expert.xml
@@ -73,10 +73,6 @@
             android:title="TLダブルクリックの防止"
             android:summary="投稿行クリック〜詳細表示までのラグ発生中にダブルクリックを起こさないようにしてみます\n運が悪いと一旦バックグラウンドに行かないとTLクリックできなくなるかも"/>
         <CheckBoxPreference
-            android:key="pref_disable_ipv6"
-            android:title="IPv6を無効化"
-            android:summary="IPv6通信を無効化し、IPv4通信が優先されるようにします(※要再起動)"/>
-        <CheckBoxPreference
             android:key="pref_enable_service"
             android:title="Serviceの常駐"
             android:summary="Serviceを常駐モードで起動します\n環境によっては動作が安定します"/>


### PR DESCRIPTION
いずれもTwitter APIが特定のケースで不具合を起こしていた時代に導入されたものであり、現在ではあまり有用ではない。

IPv6無効化オプションに至っては、これで正しく動作するか自分ではほとんど検証していなかった。(検証する環境もなかった気がする)