### PR TITLE
aboutページ内の横幅スタイルの崩れを修正

### DIFF
--- a/Yukari/src/main/assets/about.html
+++ b/Yukari/src/main/assets/about.html
@@ -2,6 +2,7 @@
 <html>
 <head>
     <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>アプリについて</title>
     <style>
         body {
@@ -22,18 +23,24 @@
         .content {
             margin: 8px;
         }
+        .license {
+            overflow-x: scroll;
+        }
     </style>
 </head>
 <body>
 <header>
     <h1>Yukari for Android</h1>
-    <p>Developed by <a href="https://twitter.com/shibafu528">@shibafu528</a>
+    <p>Developed by <a href="https://twitter.com/shibafu528">@shibafu528</a></p>
 </header>
-<div class="content">
-<p>Yukari はMastodonのマルチアカウント利用に対応したSNSクライアントアプリです。
-<p>バグや質問等のお問い合わせは<a href="https://ertona.net/@yukari4a">@yukari4a@ertona.net (Mastodon)</a>で受け付けています。
-<p>このアプリは <a href="#apache">Apache License, Version 2.0</a> でライセンスされたオープンソースソフトウェアです。
+<main class="content">
+<div class="about">
+<p>Yukari はMastodonのマルチアカウント利用に対応したSNSクライアントアプリです。</p>
+<p>バグや質問等のお問い合わせは<a href="https://ertona.net/@yukari4a">@yukari4a@ertona.net (Mastodon)</a>で受け付けています。</p>
+<p>このアプリは <a href="#apache">Apache License, Version 2.0</a> でライセンスされたオープンソースソフトウェアです。</p>
+</div>
 <hr>
+<div class="license">
 <h1>Open Source Licenses</h1>
 <ul>
     <li>Twitter4J</li>
@@ -276,5 +283,6 @@
    limitations under the License.
 </pre>
 </div>
+</main>
 </body>
 </html>


### PR DESCRIPTION
ライセンスのpreによる折り返しのないテキストによってページ全体のレイアウトが崩れていました。
pre折り返しも考えましたが、テキストの折り返しが大量に発生してライセンス表記のレイアウトが大きく崩れ、見た目が悪かったのでライセンス本文周辺のみ横スクロール可能にしてレイアウトを調整してみました。

## 修正前の状態
<img width="248" alt="スクリーンショット 2023-09-27 21 21 05" src="https://github.com/shibafu528/Yukari/assets/5732969/54e65b53-c9b8-4dfa-b378-f5925883a59c">

## 修正後の状態
<img width="242" alt="スクリーンショット 2023-09-27 21 22 07" src="https://github.com/shibafu528/Yukari/assets/5732969/b04119e2-c4d2-4d88-948e-b2a31e3da5e7">
