### PR TITLE
[Mastodon] フォロー管理画面

### DIFF
--- a/Yukari/build.gradle
+++ b/Yukari/build.gradle
@@ -187,7 +187,7 @@ dependencies {
     implementation 'androidx.activity:activity-ktx:1.4.0'
     implementation 'androidx.fragment:fragment-ktx:1.4.1'
 
-    def lifecycle_version = '2.4.1'
+    def lifecycle_version = '2.5.1'
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version"
     implementation "androidx.lifecycle:lifecycle-livedata-ktx:$lifecycle_version"
     implementation "androidx.lifecycle:lifecycle-runtime-ktx:$lifecycle_version"

--- a/Yukari/src/main/AndroidManifest.xml
+++ b/Yukari/src/main/AndroidManifest.xml
@@ -285,6 +285,10 @@
             android:windowSoftInputMode="adjustResize" />
 
         <activity
+            android:name=".activity.MastodonFollowActivity"
+            android:label="@string/title_activity_mastodon_follow" />
+
+        <activity
             android:name=".activity.NotificationPreferenceActivity"
             android:label="通知設定" />
    </application>

--- a/Yukari/src/main/java/shibafu/yukari/activity/MastodonFollowActivity.kt
+++ b/Yukari/src/main/java/shibafu/yukari/activity/MastodonFollowActivity.kt
@@ -1,0 +1,363 @@
+package shibafu.yukari.activity
+
+import android.app.Application
+import android.content.Context
+import android.content.Intent
+import android.os.Bundle
+import android.os.Parcelable
+import android.view.LayoutInflater
+import android.view.MenuItem
+import android.view.View
+import android.view.ViewGroup
+import android.widget.PopupMenu
+import android.widget.Toast
+import androidx.activity.viewModels
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.SavedStateHandle
+import androidx.lifecycle.viewModelScope
+import androidx.recyclerview.widget.DiffUtil
+import androidx.recyclerview.widget.ListAdapter
+import androidx.recyclerview.widget.RecyclerView
+import com.sys1yagi.mastodon4j.MastodonClient
+import com.sys1yagi.mastodon4j.api.entity.Relationship
+import com.sys1yagi.mastodon4j.api.method.Accounts
+import com.sys1yagi.mastodon4j.api.method.Public
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.launch
+import shibafu.yukari.R
+import shibafu.yukari.activity.base.ActionBarYukariBase
+import shibafu.yukari.common.bitmapcache.ImageLoaderTask
+import shibafu.yukari.core.App
+import shibafu.yukari.database.AuthUserRecord
+import shibafu.yukari.database.Provider
+import shibafu.yukari.databinding.ActivityMastodonFollowBinding
+import shibafu.yukari.databinding.RowFollowBinding
+import shibafu.yukari.mastodon.api.AccountsEx
+import shibafu.yukari.mastodon.entity.DonUser
+
+class MastodonFollowActivity : ActionBarYukariBase() {
+    private lateinit var binding: ActivityMastodonFollowBinding
+
+    private val model: FollowViewModel by viewModels()
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        binding = ActivityMastodonFollowBinding.inflate(layoutInflater)
+        setContentView(binding.root)
+
+        supportActionBar?.apply {
+            subtitle = "@${model.targetUser.screenName}"
+            setDisplayHomeAsUpEnabled(true)
+        }
+
+        val adapter = object : RelationStatusAdapter(model.targetUser) {
+            override fun onRelationClaim(claim: RelationState.Updating) {
+                model.postClaim(claim)
+            }
+        }
+        binding.recyclerView.adapter = adapter
+
+        adapter.submitList(model.relations.value)
+        model.relations.observe(this) {
+            adapter.submitList(it)
+        }
+
+        model.loadRelations()
+    }
+
+    override fun onOptionsItemSelected(item: MenuItem): Boolean {
+        if (item.itemId == android.R.id.home) {
+            finish()
+            return true
+        }
+        return super.onOptionsItemSelected(item)
+    }
+
+    sealed class RelationState {
+        data class Loading(override val userRecord: AuthUserRecord) : RelationState() {
+            fun success(relationship: Relationship) = Loaded(userRecord, relationship)
+            fun failed() = LoadFailed(userRecord)
+        }
+        data class LoadFailed(override val userRecord: AuthUserRecord) : RelationState() {
+            fun loading() = Loading(userRecord)
+        }
+        data class Loaded(override val userRecord: AuthUserRecord, val relationship: Relationship) : RelationState() {
+            fun claim(claim: RelationClaim) = Updating(userRecord, relationship, claim)
+        }
+        data class Updating(override val userRecord: AuthUserRecord, val relationship: Relationship, val claim: RelationClaim) : RelationState() {
+            fun success(newRelationship: Relationship) = Loaded(userRecord, newRelationship)
+            fun failed() = Loaded(userRecord, relationship)
+        }
+
+        abstract val userRecord: AuthUserRecord
+    }
+
+    enum class RelationClaim {
+        /** フォロー解除 */
+        UNFOLLOW,
+        /** フォローする */
+        FOLLOW,
+        /** ブロックする */
+        BLOCK,
+        /** ブロック解除 */
+        UNBLOCK,
+        /** 相手にフォローを解除させる */
+        REMOVE,
+    }
+
+    class FollowViewModel(application: Application, state: SavedStateHandle) : AndroidViewModel(application) {
+        private val app get() = getApplication() as App
+
+        val targetUser = state.get<DonUser>(EXTRA_TARGET_USER)!!
+        val relations = MutableLiveData<List<RelationState>>(
+            App.getInstance(application).accountManager.users
+                .filter { it.Provider.apiType == Provider.API_MASTODON }
+                .map { RelationState.Loading(it) }
+        )
+
+        fun loadRelations() {
+            val api = app.getProviderApi(Provider.API_MASTODON)
+            relations.value!!.forEach { current ->
+                val current = when (current) {
+                    is RelationState.Loading -> current
+                    is RelationState.LoadFailed -> current.loading()
+                    else -> return@forEach
+                }
+
+                viewModelScope.launch(Dispatchers.IO) {
+                    val client = api.getApiClient(current.userRecord) as MastodonClient
+                    val newRelation = runCatching {
+                        // FIXME: えっなんでDonUser#urlがnullableなの
+                        val searchResult = Public(client).getSearch(targetUser.url!!, true).execute()
+                        val account = searchResult.accounts.firstOrNull() ?: return@runCatching current.failed()
+
+                        val relationship = Accounts(client).getRelationships(listOf(account.id)).execute().first()
+                        current.success(relationship)
+                    }.getOrElse {
+                        it.printStackTrace()
+                        current.failed()
+                    }
+
+                    launch(Dispatchers.Main) {
+                        relations.value = relations.value!!.map { if (it.userRecord == newRelation.userRecord) newRelation else it }
+                    }
+                }
+            }
+        }
+
+        fun postClaim(claimState: RelationState.Updating) = viewModelScope.launch {
+            relations.value = relations.value!!.map { if (it.userRecord == claimState.userRecord) claimState else it }
+
+            val result = async(Dispatchers.IO) {
+                val api = app.getProviderApi(Provider.API_MASTODON)
+                val client = api.getApiClient(claimState.userRecord) as MastodonClient
+                val targetAccountId = claimState.relationship.id
+
+                runCatching {
+                    when (claimState.claim) {
+                        RelationClaim.UNFOLLOW -> Accounts(client).postUnFollow(targetAccountId).execute()
+                        RelationClaim.FOLLOW -> Accounts(client).postFollow(targetAccountId).execute()
+                        RelationClaim.BLOCK -> Accounts(client).postBlock(targetAccountId).execute()
+                        RelationClaim.UNBLOCK -> Accounts(client).postUnblock(targetAccountId).execute()
+                        RelationClaim.REMOVE -> AccountsEx(client).postRemoveFromFollowers(targetAccountId).execute()
+                    }
+                }
+            }.await()
+
+            val newStatus = result.fold({
+                val message = when (claimState.claim) {
+                    RelationClaim.UNFOLLOW -> app.getString(R.string.follow_control_unfollow_succeed, claimState.userRecord.ScreenName)
+                    RelationClaim.FOLLOW -> app.getString(R.string.follow_control_follow_succeed, claimState.userRecord.ScreenName)
+                    RelationClaim.BLOCK -> app.getString(R.string.follow_control_block_succeed, claimState.userRecord.ScreenName)
+                    RelationClaim.UNBLOCK -> app.getString(R.string.follow_control_unblock_succeed, claimState.userRecord.ScreenName)
+                    RelationClaim.REMOVE -> app.getString(R.string.follow_control_remove_from_followers_succeed, claimState.userRecord.ScreenName)
+                }
+                Toast.makeText(app, message, Toast.LENGTH_SHORT).show()
+
+                claimState.success(it)
+            }, {
+                it.printStackTrace()
+
+                val message = when (claimState.claim) {
+                    RelationClaim.UNFOLLOW -> app.getString(R.string.follow_control_unfollow_failed, claimState.userRecord.ScreenName)
+                    RelationClaim.FOLLOW -> app.getString(R.string.follow_control_follow_failed, claimState.userRecord.ScreenName)
+                    RelationClaim.BLOCK -> app.getString(R.string.follow_control_block_failed, claimState.userRecord.ScreenName)
+                    RelationClaim.UNBLOCK -> app.getString(R.string.follow_control_unblock_failed, claimState.userRecord.ScreenName)
+                    RelationClaim.REMOVE -> app.getString(R.string.follow_control_remove_from_followers_failed, claimState.userRecord.ScreenName)
+                }
+                Toast.makeText(app, message, Toast.LENGTH_SHORT).show()
+
+                claimState.failed()
+            })
+
+            relations.value = relations.value!!.map { if (it.userRecord == newStatus.userRecord) newStatus else it }
+        }
+    }
+
+    open class RelationStatusAdapter(private val targetUser: DonUser) : ListAdapter<RelationState, RelationStatusAdapter.ViewHolder>(DIFF_CALLBACK) {
+        class ViewHolder(private val binding: RowFollowBinding) : RecyclerView.ViewHolder(binding.root) {
+            fun bindTo(adapter: RelationStatusAdapter, targetUser: DonUser, relation: RelationState) {
+                binding.ivFoOwn.tag = relation.userRecord.ProfileImageUrl
+                ImageLoaderTask.loadProfileIcon(binding.root.context, binding.ivFoOwn, relation.userRecord.ProfileImageUrl)
+
+                binding.ivFoTarget.tag = targetUser.biggerProfileImageUrl
+                ImageLoaderTask.loadProfileIcon(binding.root.context, binding.ivFoTarget, targetUser.biggerProfileImageUrl)
+
+                if (targetUser.identicalUrl!! == relation.userRecord.IdenticalUrl) {
+                    binding.btnFollow.visibility = View.GONE
+                    binding.ibMenu.visibility = View.GONE
+                    binding.tvFoYou.visibility = View.VISIBLE
+                    return
+                }
+                binding.btnFollow.visibility = View.VISIBLE
+                binding.ibMenu.visibility = View.VISIBLE
+                binding.tvFoYou.visibility = View.GONE
+
+                when (relation) {
+                    is RelationState.Loading -> {
+                        binding.btnFollow.setText(R.string.follow_control_loading)
+                        binding.btnFollow.isEnabled = false
+                        binding.ibMenu.isEnabled = false
+                        binding.ivFollowStatus.setImageResource(R.drawable.ic_f_not)
+                    }
+                    is RelationState.LoadFailed -> {
+                        binding.btnFollow.setText(R.string.follow_control_load_failed)
+                        binding.btnFollow.isEnabled = false
+                        binding.ibMenu.isEnabled = false
+                        binding.ivFollowStatus.setImageResource(R.drawable.ic_f_not)
+                    }
+                    is RelationState.Loaded -> {
+                        binding.btnFollow.setText(
+                            when {
+                                relation.relationship.isBlocking -> R.string.follow_control_unblock
+                                relation.relationship.isFollowing -> R.string.follow_control_unfollow
+                                relation.relationship.isRequested -> R.string.follow_control_requested
+                                else -> R.string.follow_control_follow
+                            }
+                        )
+                        binding.btnFollow.isEnabled = true
+                        binding.ibMenu.isEnabled = true
+                        binding.ivFollowStatus.setImageResource(
+                            if ((relation.relationship.isFollowing || relation.relationship.isRequested) && relation.relationship.isFollowedBy) {
+                                R.drawable.ic_f_friend
+                            } else if (relation.relationship.isFollowing || relation.relationship.isRequested) {
+                                R.drawable.ic_f_follow
+                            } else if (relation.relationship.isFollowedBy) {
+                                R.drawable.ic_f_follower
+                            } else {
+                                R.drawable.ic_f_not
+                            }
+                        )
+                    }
+                    is RelationState.Updating -> {
+                        binding.btnFollow.setText(
+                            when (relation.claim) {
+                                RelationClaim.UNFOLLOW -> R.string.follow_control_unfollow_processing
+                                RelationClaim.FOLLOW -> R.string.follow_control_follow_processing
+                                RelationClaim.BLOCK -> R.string.follow_control_block_processing
+                                RelationClaim.UNBLOCK -> R.string.follow_control_unblock_processing
+                                RelationClaim.REMOVE -> R.string.follow_control_remove_from_followers_processing
+                            }
+                        )
+                        binding.btnFollow.isEnabled = false
+                        binding.ibMenu.isEnabled = false
+                        binding.ivFollowStatus.setImageResource(
+                            when (relation.claim) {
+                                RelationClaim.UNFOLLOW -> if (relation.relationship.isFollowedBy) {
+                                    R.drawable.ic_f_follower
+                                } else {
+                                    R.drawable.ic_f_not
+                                }
+                                RelationClaim.FOLLOW -> if (relation.relationship.isFollowedBy) {
+                                    R.drawable.ic_f_friend
+                                } else {
+                                    R.drawable.ic_f_follow
+                                }
+                                RelationClaim.BLOCK -> R.drawable.ic_f_not
+                                RelationClaim.UNBLOCK -> R.drawable.ic_f_not
+                                RelationClaim.REMOVE -> R.drawable.ic_f_not
+                            }
+                        )
+                    }
+                }
+
+                binding.btnFollow.setOnClickListener {
+                    if (relation !is RelationState.Loaded) {
+                        return@setOnClickListener
+                    }
+
+                    val claim = when {
+                        relation.relationship.isBlocking -> relation.claim(RelationClaim.UNBLOCK)
+                        relation.relationship.isFollowing -> relation.claim(RelationClaim.UNFOLLOW)
+                        else -> relation.claim(RelationClaim.FOLLOW)
+                    }
+                    adapter.onRelationClaim(claim)
+                }
+                binding.ibMenu.setOnClickListener {
+                    if (relation !is RelationState.Loaded) {
+                        return@setOnClickListener
+                    }
+
+                    val menu = PopupMenu(it.context, it)
+                    menu.inflate(R.menu.follow)
+
+                    val blockItem = menu.menu.findItem(R.id.action_block)
+                    blockItem.isEnabled = !relation.relationship.isBlocking
+
+                    val removeItem = menu.menu.findItem(R.id.action_remove)
+                    removeItem.isVisible = true
+                    removeItem.isEnabled = !relation.relationship.isBlocking && relation.relationship.isFollowedBy
+
+                    menu.setOnMenuItemClickListener { item ->
+                        when (item.itemId) {
+                            R.id.action_block -> {
+                                adapter.onRelationClaim(relation.claim(RelationClaim.BLOCK))
+                                true
+                            }
+                            R.id.action_remove -> {
+                                adapter.onRelationClaim(relation.claim(RelationClaim.REMOVE))
+                                true
+                            }
+                            else -> false
+                        }
+                    }
+                    menu.show()
+                }
+            }
+        }
+
+        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+            return ViewHolder(RowFollowBinding.inflate(LayoutInflater.from(parent.context), parent, false))
+        }
+
+        override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+            holder.bindTo(this, targetUser, getItem(position))
+        }
+
+        open fun onRelationClaim(claim: RelationState.Updating) {}
+
+        companion object {
+            private val DIFF_CALLBACK = object : DiffUtil.ItemCallback<RelationState>() {
+                override fun areItemsTheSame(oldItem: RelationState, newItem: RelationState): Boolean {
+                    return oldItem.userRecord.InternalId == newItem.userRecord.InternalId
+                }
+
+                override fun areContentsTheSame(oldItem: RelationState, newItem: RelationState): Boolean {
+                    return oldItem == newItem
+                }
+            }
+        }
+    }
+
+    companion object {
+        private const val EXTRA_TARGET_USER = "targetUser"
+
+        fun newIntent(context: Context, targetUser: DonUser): Intent {
+            return Intent(context, MastodonFollowActivity::class.java).apply {
+                putExtra(EXTRA_TARGET_USER, targetUser as Parcelable)
+            }
+        }
+    }
+}

--- a/Yukari/src/main/java/shibafu/yukari/activity/base/ActionBarYukariBase.java
+++ b/Yukari/src/main/java/shibafu/yukari/activity/base/ActionBarYukariBase.java
@@ -57,6 +57,12 @@ public abstract class ActionBarYukariBase extends AppCompatActivity implements T
         return getTwitterService();
     }
 
+    @Override
+    public void onServiceConnected() {}
+
+    @Override
+    public void onServiceDisconnected() {}
+
     protected boolean allowAutoTheme() {
         return true;
     }

--- a/Yukari/src/main/java/shibafu/yukari/fragment/MastodonProfileFragment.kt
+++ b/Yukari/src/main/java/shibafu/yukari/fragment/MastodonProfileFragment.kt
@@ -38,6 +38,7 @@ import kotlinx.coroutines.launch
 import org.xmlpull.v1.XmlPullParser
 import org.xmlpull.v1.XmlPullParserFactory
 import shibafu.yukari.R
+import shibafu.yukari.activity.MastodonFollowActivity
 import shibafu.yukari.activity.PreviewActivity2
 import shibafu.yukari.activity.ProfileActivity
 import shibafu.yukari.activity.TweetActivity
@@ -50,7 +51,6 @@ import shibafu.yukari.fragment.tabcontent.TimelineFragment
 import shibafu.yukari.fragment.tabcontent.TweetListFragmentFactory
 import shibafu.yukari.mastodon.entity.DonUser
 import shibafu.yukari.util.AttrUtil
-import shibafu.yukari.util.showToast
 import shibafu.yukari.view.ProfileButton
 import java.io.StringReader
 import java.time.ZonedDateTime
@@ -83,6 +83,7 @@ class MastodonProfileFragment : Fragment(), CoroutineScope, SimpleAlertDialogFra
     private lateinit var tvMovedScreenName: TextView
     private lateinit var cvFields: CardView
     private lateinit var llFields: LinearLayout
+    private lateinit var btnFollowManage: Button
 
     private lateinit var currentUser: AuthUserRecord
     private lateinit var targetUrl: Uri
@@ -227,9 +228,10 @@ class MastodonProfileFragment : Fragment(), CoroutineScope, SimpleAlertDialogFra
         cvFields = v.findViewById(R.id.cvProfileFields)
         llFields = v.findViewById(R.id.llProfileFields)
 
-        val btnFollowManage = v.findViewById<Button>(R.id.btnProfileFollow)
+        btnFollowManage = v.findViewById<Button>(R.id.btnProfileFollow)
         btnFollowManage.setOnClickListener {
-            showToast("まだ未対応です")
+            val user = targetUser ?: return@setOnClickListener
+            startActivity(MastodonFollowActivity.newIntent(requireContext(), user))
         }
 
         val appBarLayout = v.findViewById<AppBarLayout>(R.id.appBarLayout)

--- a/Yukari/src/main/java/shibafu/yukari/mastodon/api/AccountsEx.kt
+++ b/Yukari/src/main/java/shibafu/yukari/mastodon/api/AccountsEx.kt
@@ -1,0 +1,24 @@
+package shibafu.yukari.mastodon.api
+
+import com.sys1yagi.mastodon4j.MastodonClient
+import com.sys1yagi.mastodon4j.MastodonRequest
+import com.sys1yagi.mastodon4j.api.entity.Relationship
+import com.sys1yagi.mastodon4j.extension.emptyRequestBody
+
+class AccountsEx(private val client: MastodonClient) {
+    /**
+     * POST /api/v1/accounts/:id/remove_from_followers
+     *
+     * [Document](https://docs.joinmastodon.org/methods/accounts/#remove_from_followers)
+     */
+    fun postRemoveFromFollowers(accountId: Long): MastodonRequest<Relationship> {
+        return MastodonRequest<Relationship>(
+            {
+                client.post("accounts/$accountId/remove_from_followers", emptyRequestBody())
+            },
+            {
+                client.getSerializer().fromJson(it, Relationship::class.java)
+            }
+        )
+    }
+}

--- a/Yukari/src/main/res/layout/activity_mastodon_follow.xml
+++ b/Yukari/src/main/res/layout/activity_mastodon_follow.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recyclerView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager" />
+</FrameLayout>

--- a/Yukari/src/main/res/layout/row_follow.xml
+++ b/Yukari/src/main/res/layout/row_follow.xml
@@ -2,7 +2,7 @@
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent"
+    android:layout_height="wrap_content"
     android:paddingLeft="4dp"
     android:paddingRight="4dp"
     android:paddingTop="6dp"

--- a/Yukari/src/main/res/menu/follow.xml
+++ b/Yukari/src/main/res/menu/follow.xml
@@ -2,10 +2,14 @@
 
 <menu xmlns:android="http://schemas.android.com/apk/res/android">
     <item android:id="@+id/action_block"
-        android:title="ブロックする" />
+        android:title="@string/follow_control_block" />
     <item android:id="@+id/action_cutoff"
         android:visible="false"
         android:title="ブロブロ解除" />
     <item android:id="@+id/action_report"
+        android:visible="false"
         android:title="スパム報告" />
+    <item android:id="@+id/action_remove"
+        android:visible="false"
+        android:title="@string/follow_control_remove_from_followers" />
 </menu>

--- a/Yukari/src/main/res/values/strings.xml
+++ b/Yukari/src/main/res/values/strings.xml
@@ -11,6 +11,8 @@
 
     <string name="activity_animation_duration">300</string>
 
+    <string name="button_ok">OK</string>
+    <string name="button_cancel">キャンセル</string>
     <string name="button_next">次へ</string>
     <string name="button_send">送信</string>
 
@@ -124,4 +126,8 @@
     <string name="follow_control_unblock_failed">ブロック解除に失敗しました (\@%1$s)</string>
     <string name="follow_control_remove_from_followers_succeed">フォロワーから削除しました (\@%1$s)</string>
     <string name="follow_control_remove_from_followers_failed">フォロワーからの削除に失敗しました (\@%1$s)</string>
+    <string name="follow_control_unfollow_confirm">\@%1$s から \@%2$s へのフォローを解除してもよろしいですか？</string>
+    <string name="follow_control_block_confirm">\@%1$s から \@%2$s をブロックしてもよろしいですか？</string>
+    <string name="follow_control_unblock_confirm">\@%1$s から \@%2$s へのブロックを解除してもよろしいですか？</string>
+    <string name="follow_control_remove_from_followers_confirm">\@%1$s を \@%2$s のフォロワーから削除してもよろしいですか？</string>
 </resources>

--- a/Yukari/src/main/res/values/strings.xml
+++ b/Yukari/src/main/res/values/strings.xml
@@ -44,6 +44,7 @@
     <string name="title_activity_backup_export">設定のエクスポート</string>
     <string name="title_activity_channel_manage">ストリーミング接続管理</string>
     <string name="title_activity_mastodon_report">通報</string>
+    <string name="title_activity_mastodon_follow">フォロー状態</string>
 
     <string name="drive_error_connect">Driveとの接続に失敗しました</string>
     <string name="drive_importing">インポート中…</string>
@@ -99,4 +100,28 @@
     <string name="oauth_success_fragment_finish_first">タイムラインを開く</string>
 
     <string name="notification_preference_activity_notify_toast">ポップアップ通知</string>
+
+    <string name="follow_control_loading">読み込み中…</string>
+    <string name="follow_control_load_failed">読み込みエラー</string>
+    <string name="follow_control_follow">フォローする</string>
+    <string name="follow_control_unfollow">フォロー解除</string>
+    <string name="follow_control_block">ブロックする</string>
+    <string name="follow_control_unblock">ブロック解除</string>
+    <string name="follow_control_remove_from_followers">フォロワーから削除</string>
+    <string name="follow_control_requested">フォローリクエスト中</string>
+    <string name="follow_control_follow_processing">フォロー中…</string>
+    <string name="follow_control_unfollow_processing">フォロー解除中…</string>
+    <string name="follow_control_block_processing">ブロック中…</string>
+    <string name="follow_control_unblock_processing">ブロック解除中…</string>
+    <string name="follow_control_remove_from_followers_processing">削除中…</string>
+    <string name="follow_control_follow_succeed">フォローしました (\@%1$s)</string>
+    <string name="follow_control_follow_failed">フォローに失敗しました (\@%1$s)</string>
+    <string name="follow_control_unfollow_succeed">フォローを解除しました (\@%1$s)</string>
+    <string name="follow_control_unfollow_failed">フォロー解除に失敗しました (\@%1$s)</string>
+    <string name="follow_control_block_succeed">ブロックしました (\@%1$s)</string>
+    <string name="follow_control_block_failed">ブロックに失敗しました (\@%1$s)</string>
+    <string name="follow_control_unblock_succeed">ブロックを解除しました (\@%1$s)</string>
+    <string name="follow_control_unblock_failed">ブロック解除に失敗しました (\@%1$s)</string>
+    <string name="follow_control_remove_from_followers_succeed">フォロワーから削除しました (\@%1$s)</string>
+    <string name="follow_control_remove_from_followers_failed">フォロワーからの削除に失敗しました (\@%1$s)</string>
 </resources>


### PR DESCRIPTION
refs #176 

フォロー・リムーブ・ブロック等の操作を行う画面を追加。

サーバーサイドミュート、通知ミュート、ブースト非表示などの操作には現状非対応。Twitter版のフォロー管理機能で対応していた範囲のみをカバーした。