### PR TITLE
代表アカウント再決定の可変性をタイムライン内に閉じ込める

### DIFF
--- a/Yukari/src/main/java/shibafu/yukari/common/TweetAdapter.java
+++ b/Yukari/src/main/java/shibafu/yukari/common/TweetAdapter.java
@@ -16,6 +16,7 @@ import shibafu.yukari.database.UserExtras;
 import shibafu.yukari.entity.ExceptionStatus;
 import shibafu.yukari.entity.LoadMarker;
 import shibafu.yukari.entity.Status;
+import shibafu.yukari.entity.TimelineStatus;
 import shibafu.yukari.linkage.StatusLoader;
 import shibafu.yukari.mastodon.entity.DonNotification;
 import shibafu.yukari.mastodon.entity.DonStatus;
@@ -96,6 +97,9 @@ public class TweetAdapter extends BaseAdapter {
     @Override
     public Status getItem(int position) {
         Status status = statuses.get(position);
+        if (status instanceof TimelineStatus<?>) {
+            status = ((TimelineStatus<?>) status).getRepresentStatus();
+        }
         if (status instanceof DonNotification) {
             DonNotification dn = (DonNotification) status;
             // メンション通知は中身のStatusを直接List itemとして扱う

--- a/Yukari/src/main/java/shibafu/yukari/database/Bookmark.kt
+++ b/Yukari/src/main/java/shibafu/yukari/database/Bookmark.kt
@@ -38,12 +38,6 @@ class Bookmark private constructor(val twitterStatus: TwitterStatus, private val
         return twitterStatus.hashCode()
     }
 
-    // あえてoverrideしておかないとdelegateされてバグる
-    @Suppress("RedundantOverride")
-    override fun merge(status: Status): Status {
-        return super.merge(status)
-    }
-
     override fun getContentValues(): ContentValues {
         val values = ContentValues()
         values.put(CentralDatabase.COL_BOOKMARKS_ID, twitterStatus.id)

--- a/Yukari/src/main/java/shibafu/yukari/entity/ExceptionStatus.kt
+++ b/Yukari/src/main/java/shibafu/yukari/entity/ExceptionStatus.kt
@@ -8,7 +8,7 @@ import java.util.*
  * 例外情報のラッパー
  */
 class ExceptionStatus(override val id: Long,
-                      override var representUser: AuthUserRecord,
+                      override val receiverUser: AuthUserRecord,
                       val exception: Exception) : Status {
     override val user: User = object : User {
         override val id: Long = representUser.NumericId
@@ -24,13 +24,13 @@ class ExceptionStatus(override val id: Long,
     override val recipientScreenName: String = ""
     override val createdAt: Date = Date()
     override val source: String = "System"
-    override var favoritesCount: Int = 0
-    override var repostsCount: Int = 0
+    override val favoritesCount: Int = 0
+    override val repostsCount: Int = 0
     override val metadata: StatusPreforms = StatusPreforms()
     override val providerApiType: Int = Provider.API_SYSTEM
     override val providerHost: String = HOST
-    override var representOverrode: Boolean = false
-    override var receivedUsers: MutableList<AuthUserRecord> = arrayListOf(representUser)
+    override var preferredOwnerUser: AuthUserRecord? = null
+    override var prioritizedUser: AuthUserRecord? = null
 
     companion object {
         const val HOST = "exception.yukari.internal"

--- a/Yukari/src/main/java/shibafu/yukari/entity/InReplyToId.kt
+++ b/Yukari/src/main/java/shibafu/yukari/entity/InReplyToId.kt
@@ -11,6 +11,8 @@ import com.google.gson.Gson
  */
 class InReplyToId(val url: String) : Parcelable {
     private val perProviderId = HashMap<String, String>()
+    val entries: Set<Map.Entry<String, String>>
+        get() = perProviderId.entries
 
     constructor(parcel: Parcel) : this(parcel.readString().orEmpty()) {
         val perProviderIdSize = parcel.readInt()

--- a/Yukari/src/main/java/shibafu/yukari/entity/LoadMarker.kt
+++ b/Yukari/src/main/java/shibafu/yukari/entity/LoadMarker.kt
@@ -8,7 +8,7 @@ import java.util.*
  * @param id 読み込みを開始する位置のID (maxId)
  * @param providerApiType 対応する [shibafu.yukari.database.Provider.apiType] の値
  * @param anchorStatusId 先行するステータスのID
- * @param representUser 対応するアカウント
+ * @param receiverUser 対応するアカウント
  * @param loadMarkerTag 対応するクエリを表すタグ
  * @param createdAt タイムスタンプ
  * @param stringCursor ページング追加情報
@@ -17,7 +17,7 @@ import java.util.*
 class LoadMarker(override val id: Long,
                  override val providerApiType: Int,
                  val anchorStatusId: Long,
-                 override var representUser: AuthUserRecord,
+                 override val receiverUser: AuthUserRecord,
                  val loadMarkerTag: String,
                  override val createdAt: Date,
                  val stringCursor: String = "",
@@ -26,7 +26,7 @@ class LoadMarker(override val id: Long,
     var taskKey = -1L
 
     override val user: User = object : User {
-        override val id: Long = representUser.NumericId
+        override val id: Long = receiverUser.NumericId
         override val name: String = ""
         override val screenName: String = "**Load Marker**"
         override val isProtected: Boolean = false
@@ -36,16 +36,16 @@ class LoadMarker(override val id: Long,
     }
 
     override val text: String
-        get() = "Anchor ID = $anchorStatusId, API = $providerApiType, UID = ${representUser.NumericId}, Tag = $loadMarkerTag, TaskKey = $taskKey"
+        get() = "Anchor ID = $anchorStatusId, API = $providerApiType, UID = ${receiverUser.NumericId}, Tag = $loadMarkerTag, TaskKey = $taskKey"
 
     override val recipientScreenName: String = "**Load Marker**"
     override val source: String = ""
-    override var favoritesCount: Int = 0
-    override var repostsCount: Int = 0
+    override val favoritesCount: Int = 0
+    override val repostsCount: Int = 0
     override val metadata: StatusPreforms = StatusPreforms()
-    override var representOverrode: Boolean = false
-    override var receivedUsers: MutableList<AuthUserRecord> = arrayListOf(representUser)
     override val providerHost: String = HOST
+    override var preferredOwnerUser: AuthUserRecord? = null
+    override var prioritizedUser: AuthUserRecord? = null
 
     companion object {
         const val HOST = "load-marker.yukari.internal"

--- a/Yukari/src/main/java/shibafu/yukari/entity/MergeableStatus.kt
+++ b/Yukari/src/main/java/shibafu/yukari/entity/MergeableStatus.kt
@@ -10,4 +10,13 @@ interface MergeableStatus {
      * 戻り値が取りうる値は [Comparable.compareTo] と同じで、昇順に並び替えて先頭に来たものが最優先となる。
      */
     fun compareMergePriorityTo(other: Status): Int
+
+    /**
+     * レシーバーを、タイムライン上でマージされた状態から切り離す。
+     *
+     * 引数には他にマージされていたステータスが与えられる。必要に応じて他のステータスのサーバーローカル情報などをコピーするために使用できる。
+     *
+     * 戻り値として、レシーバー自身または切り離した状態を表す新しいステータスを返すこと。
+     */
+    fun unmerge(followers: List<Status>): Status
 }

--- a/Yukari/src/main/java/shibafu/yukari/entity/MergeableStatus.kt
+++ b/Yukari/src/main/java/shibafu/yukari/entity/MergeableStatus.kt
@@ -1,0 +1,13 @@
+package shibafu.yukari.entity
+
+/**
+ * タイムライン上でマージ可能な [Status] であることを表すインターフェース。
+ */
+interface MergeableStatus {
+    /**
+     * レシーバーと指定されたオブジェクトの間で、マージした際の表示優先度を比較する。
+     *
+     * 戻り値が取りうる値は [Comparable.compareTo] と同じで、昇順に並び替えて先頭に来たものが最優先となる。
+     */
+    fun compareMergePriorityTo(other: Status): Int
+}

--- a/Yukari/src/main/java/shibafu/yukari/entity/MockStatus.kt
+++ b/Yukari/src/main/java/shibafu/yukari/entity/MockStatus.kt
@@ -7,7 +7,7 @@ import java.util.*
 /**
  * ステータスのモック
  */
-open class MockStatus(override val id: Long, override var representUser: AuthUserRecord) : Status {
+open class MockStatus(override val id: Long, override val receiverUser: AuthUserRecord) : Status {
     override val user: User = object : User {
         override val id: Long = this@MockStatus.id
         override val name: String = "Error"
@@ -22,13 +22,13 @@ open class MockStatus(override val id: Long, override var representUser: AuthUse
     override val recipientScreenName: String = ""
     override val createdAt: Date = Date()
     override val source: String = "System"
-    override var favoritesCount: Int = 0
-    override var repostsCount: Int = 0
+    override val favoritesCount: Int = 0
+    override val repostsCount: Int = 0
     override val metadata: StatusPreforms = StatusPreforms()
     override val providerApiType: Int = Provider.API_SYSTEM
     override val providerHost: String = HOST
-    override var representOverrode: Boolean = false
-    override var receivedUsers: MutableList<AuthUserRecord> = arrayListOf(representUser)
+    override var preferredOwnerUser: AuthUserRecord? = null
+    override var prioritizedUser: AuthUserRecord? = null
 
     companion object {
         const val HOST = "mock.yukari.internal"

--- a/Yukari/src/main/java/shibafu/yukari/entity/Status.kt
+++ b/Yukari/src/main/java/shibafu/yukari/entity/Status.kt
@@ -179,13 +179,6 @@ interface Status : Comparable<Status>, Serializable, Cloneable {
     }
 
     /**
-     * 指定したアカウントで代表受信アカウントを上書きし、ロックする
-     */
-    fun setRepresentUserAndLock(user: AuthUserRecord) {
-        prioritizedUser = user
-    }
-
-    /**
      * このステータスがいずれかの受信アカウントにメンションを向けているか判断
      */
     fun isMentionedToMe(): Boolean {

--- a/Yukari/src/main/java/shibafu/yukari/entity/Status.kt
+++ b/Yukari/src/main/java/shibafu/yukari/entity/Status.kt
@@ -142,13 +142,20 @@ interface Status : Comparable<Status>, Serializable, Cloneable {
     fun setRepresentIfOwned(userRecords: List<AuthUserRecord>) {
         userRecords.forEach { userRecord ->
             if (providerApiType == userRecord.Provider.apiType && originStatus.user.url == userRecord.Url) {
-                representUser = userRecord
-                representOverrode = true
-                if (!receivedUsers.contains(userRecord)) {
-                    receivedUsers.add(userRecord)
-                }
+                setRepresentUserAndLock(userRecord)
                 return
             }
+        }
+    }
+
+    /**
+     * 指定したアカウントで代表受信アカウントを上書きし、ロックする
+     */
+    fun setRepresentUserAndLock(user: AuthUserRecord) {
+        representUser = user
+        representOverrode = true
+        if (!receivedUsers.contains(user)) {
+            receivedUsers.add(user)
         }
     }
 

--- a/Yukari/src/main/java/shibafu/yukari/entity/Status.kt
+++ b/Yukari/src/main/java/shibafu/yukari/entity/Status.kt
@@ -4,7 +4,6 @@ import shibafu.yukari.media2.Media
 import shibafu.yukari.database.AuthUserRecord
 import java.io.Serializable
 import java.util.*
-import kotlin.collections.ArrayList
 
 /**
  * タイムラインに表示できたりするやつ
@@ -93,12 +92,12 @@ interface Status : Comparable<Status>, Serializable, Cloneable {
     /**
      * お気に入り登録数
      */
-    var favoritesCount: Int
+    val favoritesCount: Int
 
     /**
      * 引用数
      */
-    var repostsCount: Int
+    val repostsCount: Int
 
     /**
      * メタデータ
@@ -116,19 +115,50 @@ interface Status : Comparable<Status>, Serializable, Cloneable {
     val providerHost: String
 
     /**
-     * 代表受信アカウント
+     * このステータスを受信したアカウント
+     *
+     * 通信先 [shibafu.yukari.database.Provider] が異なる同一内容のステータスがある状況では、共通情報・サーバーローカル情報の取り違いを避けるための判定にも使われる。
+     * そのため、直接の通信先と関係の無いアカウントを返してはいけない。
      */
-    var representUser: AuthUserRecord
+    val receiverUser: AuthUserRecord
 
     /**
-     * 代表受信アカウントが高優先度なアカウントでロックされているかどうか
+     * このステータスを所有している受信アカウント
+     *
+     * 通常、ステータスを受信して [shibafu.yukari.linkage.TimelineHub] で配送される時に設定される。
+     * このプロパティは [prioritizedUser] より優先して扱う必要がある。
      */
-    var representOverrode: Boolean
+    var preferredOwnerUser: AuthUserRecord?
+
+    /**
+     * 操作用に優先設定されている受信アカウント
+     *
+     * [shibafu.yukari.database.UserExtras.priorityAccount] に基づいて設定される。
+     */
+    var prioritizedUser: AuthUserRecord?
+
+    /**
+     * 代表受信アカウント
+     *
+     * [preferredOwnerUser] および [prioritizedUser] を考慮して、操作用のアカウントを返す。
+     * ステータスのサーバーローカル情報とは関係のないアカウントが返される可能性もあるため、APIリクエストの際には改めてIDの問い合わせが必要となる場合もある。
+     */
+    val representUser: AuthUserRecord
+        get() {
+            preferredOwnerUser?.let { return it }
+            prioritizedUser?.let { return it }
+            return receiverUser
+        }
 
     /**
      * 同一のステータスを受信した全てのアカウント
      */
-    var receivedUsers: MutableList<AuthUserRecord>
+    val receivedUsers: List<AuthUserRecord>
+        get() = sequence {
+            preferredOwnerUser?.let { yield(it) }
+            prioritizedUser?.let { yield(it) }
+            yield(receiverUser)
+        }.distinct().toList()
 
     /**
      * 自分にとってどのような関係性のあるメッセージか判断
@@ -142,7 +172,7 @@ interface Status : Comparable<Status>, Serializable, Cloneable {
     fun setRepresentIfOwned(userRecords: List<AuthUserRecord>) {
         userRecords.forEach { userRecord ->
             if (providerApiType == userRecord.Provider.apiType && originStatus.user.url == userRecord.Url) {
-                setRepresentUserAndLock(userRecord)
+                preferredOwnerUser = userRecord
                 return
             }
         }
@@ -152,11 +182,7 @@ interface Status : Comparable<Status>, Serializable, Cloneable {
      * 指定したアカウントで代表受信アカウントを上書きし、ロックする
      */
     fun setRepresentUserAndLock(user: AuthUserRecord) {
-        representUser = user
-        representOverrode = true
-        if (!receivedUsers.contains(user)) {
-            receivedUsers.add(user)
-        }
+        prioritizedUser = user
     }
 
     /**
@@ -189,72 +215,6 @@ interface Status : Comparable<Status>, Serializable, Cloneable {
      * 指定したアカウントで、このステータスをお気に入りできるか？
      */
     fun canFavorite(userRecord: AuthUserRecord): Boolean = false
-
-    /**
-     * 同じ内容を指す、より新しい別インスタンスの情報と比較してなるべく最新かつ情報の完全性が高いインスタンスを返す
-     */
-    fun merge(status: Status): Status {
-        if (this === status) {
-            return this
-        }
-
-        if (this != status || this.providerApiType != status.providerApiType) {
-            throw IllegalArgumentException("マージは両インスタンスがEqualsかつAPI Typeが揃っていないと実行できません。this[URL=$url, API=$providerApiType] : args[URL=${status.url}, API=${status.providerApiType}]")
-        }
-
-        favoritesCount = status.favoritesCount
-        repostsCount = status.repostsCount
-
-        status.receivedUsers.forEach { userRecord ->
-            if (!receivedUsers.contains(userRecord)) {
-                receivedUsers.add(userRecord)
-            }
-            if (status.metadata.favoritedUsers.get(userRecord.InternalId)) {
-                metadata.favoritedUsers.put(userRecord.InternalId, true)
-            }
-        }
-        status.receivedUsers = receivedUsers
-        status.metadata.favoritedUsers = metadata.favoritedUsers
-
-        // 代表アカウントの再決定
-        /*
-         * 代表アカウントは次の優先順位で決定する。
-         *
-         * 1. Statusの所有者 (originStatus.user本人)
-         * 2. 優先設定されたアカウント
-         * 3. Mentionsで指名されたアカウント (Mentions内に所有するアカウントが複数ある場合、Mentions内でindexが一番若いアカウント)
-         * 4. プライマリアカウント
-         * 5. その他のアカウント
-         *
-         * このうち、1〜2については「高優先度判定」としてここでは取り扱わない。
-         * (外部で決定し、その際にrepresentOverrodeフラグを設定することでマージ時の代表再決定をスキップする)
-         *
-         * 3〜5については、マージ対象となる2つのStatus双方のreceivedUsersを先にマージし、そこに含まれるアカウント間で決定する。
-         */
-        if (!representOverrode && status.representOverrode) {
-            representOverrode = true
-            representUser = status.representUser
-        } else if (representOverrode && !status.representOverrode) {
-            status.representOverrode = true
-            status.representUser = representUser
-        } else if (!representOverrode && !status.representOverrode) {
-            // メンションを受けているアカウントがあれば、そのアカウントで上書き
-            val mentioned = mentions.mapNotNull { mention -> receivedUsers.firstOrNull(mention::isMentionedTo) }.firstOrNull()
-            if (mentioned != null) {
-                representUser = mentioned
-                status.representUser = mentioned
-            } else {
-                // 受信アカウントの中にプライマリアカウントがいれば、そのアカウントで上書き
-                val primary = receivedUsers.firstOrNull { it.isPrimary }
-                if (primary != null) {
-                    representUser = primary
-                    status.representUser = primary
-                }
-            }
-        }
-
-        return this
-    }
 
     /**
      * ShareTwitterOnTumblr形式に変換する
@@ -295,9 +255,7 @@ interface Status : Comparable<Status>, Serializable, Cloneable {
     }
 
     public override fun clone(): Status {
-        val s = super.clone() as Status
-        s.receivedUsers = ArrayList(receivedUsers)
-        return s
+        return super.clone() as Status
     }
 
     fun getTextWithoutMentions(): String {

--- a/Yukari/src/main/java/shibafu/yukari/entity/Status.kt
+++ b/Yukari/src/main/java/shibafu/yukari/entity/Status.kt
@@ -36,7 +36,7 @@ interface Status : Comparable<Status>, Serializable, Cloneable {
     /**
      * 代表受信アカウントのスクリーンネーム
      */
-    val recipientScreenName: String
+    val recipientScreenName: String // TODO: たぶんいらない
 
     /**
      * メッセージのタイムスタンプ

--- a/Yukari/src/main/java/shibafu/yukari/entity/StatusComparator.kt
+++ b/Yukari/src/main/java/shibafu/yukari/entity/StatusComparator.kt
@@ -1,0 +1,10 @@
+package shibafu.yukari.entity
+
+object StatusComparator {
+    val BY_OWNED_STATUS = Comparator.comparing<Status, _> { !it.isOwnedStatus() }
+    val BY_MENTIONED = Comparator.comparing<Status, _> { status ->
+        status.mentions.find { it.isMentionedTo(status.representUser) } == null
+    }
+    val BY_PRIMARY_ACCOUNT_RECEIVED = Comparator.comparing<Status, _> { !it.representUser.isPrimary }
+    val BY_RECEIVER_ID = Comparator.comparingLong<Status> { it.representUser.InternalId }
+}

--- a/Yukari/src/main/java/shibafu/yukari/entity/StatusPreforms.kt
+++ b/Yukari/src/main/java/shibafu/yukari/entity/StatusPreforms.kt
@@ -9,7 +9,7 @@ import java.io.Serializable
 /**
  * 主に前処理の段階で決定しておく、ステータスのメタ情報など
  */
-class StatusPreforms : Serializable, Parcelable {
+class StatusPreforms : Serializable, Parcelable, Cloneable {
     /**
      * 表示すべきでないメディアを含んでいるかどうか
      */
@@ -37,6 +37,12 @@ class StatusPreforms : Serializable, Parcelable {
      */
     val isTooManyRepeatText: Boolean
         get() = repeatedSequence != null
+
+    public override fun clone(): StatusPreforms {
+        val sp = super.clone() as StatusPreforms
+        sp.favoritedUsers = LongBooleanHashMap(favoritedUsers)
+        return sp
+    }
 
     //<editor-fold desc="Parcelable">
     override fun describeContents(): Int = 0

--- a/Yukari/src/main/java/shibafu/yukari/entity/TimelineStatus.kt
+++ b/Yukari/src/main/java/shibafu/yukari/entity/TimelineStatus.kt
@@ -15,6 +15,7 @@ class TimelineStatus<T>(
     private var _representUser: AuthUserRecord? = null,
     private var _representOverrode: Boolean? = null
 ) : Status, Parcelable where T : Status, T : MergeableStatus {
+    constructor(status: T) : this(listOf(status))
     constructor(first: T, second: T) : this(upsertStatusBy(listOf(first), second))
 
     private val statuses = statuses.sortedWith { lhs, rhs ->

--- a/Yukari/src/main/java/shibafu/yukari/entity/TimelineStatus.kt
+++ b/Yukari/src/main/java/shibafu/yukari/entity/TimelineStatus.kt
@@ -1,0 +1,241 @@
+package shibafu.yukari.entity
+
+import android.os.Parcel
+import android.os.Parcelable
+import shibafu.yukari.database.AuthUserRecord
+import shibafu.yukari.database.Provider
+import shibafu.yukari.mastodon.entity.DonStatus
+import shibafu.yukari.media2.Media
+import java.util.Date
+
+/**
+ * タイムライン上で同一の [Status] を1つにまとめるためのもの。
+ */
+class TimelineStatus<T>(
+    statuses: List<T>,
+    private var _representUser: AuthUserRecord? = null,
+    private var _representOverrode: Boolean? = null
+) : Status, Parcelable where T : Status, T : MergeableStatus {
+    constructor(first: T, second: T) : this(upsertStatusBy(listOf(first), second))
+
+    private val statuses = statuses.sortedWith(MergeableStatus::compareMergePriorityTo)
+    val representStatus = this.statuses.first()
+
+    override val id: Long
+        get() = representStatus.id
+    override val url: String?
+        get() = representStatus.url
+    override val user: User
+        get() = representStatus.user
+    override val text: String
+        get() = representStatus.text
+    override val recipientScreenName: String
+        get() = representStatus.recipientScreenName
+    override val createdAt: Date
+        get() = representStatus.createdAt
+    override val source: String
+        get() = representStatus.source
+    override val isRepost: Boolean
+        get() = representStatus.isRepost
+    override val originStatus: Status
+        get() = representStatus.originStatus
+    override val inReplyToId: Long
+        get() = representStatus.inReplyToId
+    override val mentions: List<Mention>
+        get() = representStatus.mentions
+    override val media: List<Media>
+        get() = representStatus.media
+    override val links: List<String>
+        get() = representStatus.links
+    override val tags: List<String>
+        get() = representStatus.tags
+
+    private var _favoritesCount: Int? = null
+    override var favoritesCount: Int
+        get() = _favoritesCount ?: representStatus.favoritesCount
+        set(value) {
+            _favoritesCount = value
+        }
+
+    private var _repostsCount: Int? = null
+    override var repostsCount: Int
+        get() = _repostsCount ?: representStatus.repostsCount
+        set(value) {
+            _repostsCount = value
+        }
+
+    override val metadata = representStatus.metadata.clone().also { sp ->
+        statuses.drop(1).forEach { status ->
+            sp.favoritedUsers.putAll(status.metadata.favoritedUsers)
+        }
+    }
+
+    override val providerApiType: Int
+        get() = representStatus.providerApiType
+    override val providerHost: String
+        get() = representStatus.providerHost
+
+    override var representUser: AuthUserRecord
+        get() = _representUser ?: representStatus.representUser
+        set(value) {
+            _representUser = value
+        }
+    override var representOverrode: Boolean
+        get() = _representOverrode ?: representStatus.representOverrode
+        set(value) {
+            _representOverrode = value
+        }
+
+    override var receivedUsers: MutableList<AuthUserRecord>
+        get() = statuses.flatMap { it.receivedUsers }.let { list -> _representUser?.let { user -> list + user } ?: list }.distinct().toMutableList()
+        set(_) {} // Status#clone, Status#merge でしか使われていない。外部からの上書きを許す理由がないので無視。
+
+    private val _inReplyTo: InReplyToId by lazy {
+        val inReplyTo = representStatus.getInReplyTo()
+        statuses.drop(1).forEach { status ->
+            status.getInReplyTo().entries.forEach { (key, value) ->
+                if (inReplyTo[Provider.API_MASTODON, key] == null) {
+                    inReplyTo[Provider.API_MASTODON, key] = value
+                }
+            }
+        }
+        inReplyTo
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        return representStatus.javaClass == other?.javaClass && representStatus == other
+    }
+
+    override fun hashCode(): Int {
+        return representStatus.hashCode()
+    }
+
+    override fun getStatusRelation(userRecords: List<AuthUserRecord>): Int {
+        statuses.forEach { status ->
+            val relation = status.getStatusRelation(userRecords)
+            if (relation != Status.RELATION_NONE) {
+                return relation
+            }
+        }
+        return Status.RELATION_NONE
+    }
+
+    override fun canRepost(userRecord: AuthUserRecord): Boolean {
+        return representStatus.canRepost(userRecord)
+    }
+
+    override fun canFavorite(userRecord: AuthUserRecord): Boolean {
+        return representStatus.canFavorite(userRecord)
+    }
+
+    override fun merge(status: Status): Status {
+        // immutableなマージ処理を行いたいので super.merge() は呼び出さない。
+
+        if (this === status) {
+            return this
+        }
+
+        if (status !is MergeableStatus) {
+            throw IllegalArgumentException("マージするにはMergeableStatusを実装している必要があります")
+        }
+        if (representStatus.javaClass != status.javaClass) {
+            throw IllegalArgumentException("同じ型同士のStatusでないとマージできません (receiver = ${representStatus.javaClass}, given = ${status.javaClass})")
+        }
+
+        return TimelineStatus(upsertStatusBy(statuses, status), _representUser, _representOverrode)
+    }
+
+    override fun getInReplyTo(): InReplyToId = _inReplyTo
+
+    override fun describeContents(): Int = 0
+
+    override fun writeToParcel(dest: Parcel, flags: Int) {
+        dest.writeInt(statuses.size)
+        statuses.forEach { status ->
+            if (status is Parcelable) {
+                dest.writeInt(1)
+                dest.writeParcelable(status, 0)
+            } else {
+                dest.writeInt(0)
+                dest.writeSerializable(status)
+            }
+        }
+        dest.writeSerializable(_representUser)
+        dest.writeInt(
+            when (_representOverrode) {
+                null -> -1
+                false -> 0
+                true -> 1
+            }
+        )
+    }
+
+    companion object {
+        @JvmField val CREATOR = object : Parcelable.Creator<TimelineStatus<*>> {
+            override fun createFromParcel(source: Parcel): TimelineStatus<*> {
+                val statusesSize = source.readInt()
+                val statuses = (0..<statusesSize).map {
+                    val status = when (source.readInt()) {
+                        0 -> source.readSerializable()
+                        1 -> source.readParcelable(javaClass.classLoader)!!
+                        else -> throw RuntimeException("invalid type code")
+                    }
+                    if (status is Status && status is MergeableStatus) {
+                        status
+                    } else {
+                        throw RuntimeException("Status, MergeableStatusを実装していないオブジェクト")
+                    }
+                }
+                val representUser = source.readSerializable() as? AuthUserRecord
+                val representOverrode = when (source.readInt()) {
+                    -1 -> null
+                    0 -> false
+                    else -> true
+                }
+
+                return TimelineStatus(statuses, representUser, representOverrode)
+            }
+
+            override fun newArray(size: Int): Array<TimelineStatus<*>?> {
+                return arrayOfNulls(size)
+            }
+        }
+
+        private val BY_OWNED_STATUS = Comparator.comparing<DonStatus, _> { !it.isOwnedStatus() }
+        private val BY_REPRESENT_OVERRODE = Comparator.comparing<DonStatus, _> { !it.representOverrode }
+        private val BY_MENTIONED = Comparator.comparing<DonStatus, _> { status ->
+            status.mentions.find { it.isMentionedTo(status.representUser) } == null
+        }
+        private val BY_PRIMARY_ACCOUNT_RECEIVED = Comparator.comparing<DonStatus, _> { !it.representUser.isPrimary }
+        private val BY_LOCAL_STATUS = Comparator.comparing<DonStatus, _> { !it.isLocal }
+        private val BY_RECEIVER_ID = Comparator.comparingLong<DonStatus> { status ->
+            status.representUser.InternalId
+        }
+
+        private val COMPARATOR = BY_OWNED_STATUS
+            .then(BY_REPRESENT_OVERRODE)
+            .then(BY_MENTIONED)
+            .then(BY_PRIMARY_ACCOUNT_RECEIVED)
+            .then(BY_LOCAL_STATUS)
+            .then(BY_RECEIVER_ID)
+
+        private fun <T : Status> upsertStatusBy(statuses: List<T>, newStatus: T): List<T> {
+            var replaced = false
+            val newStatuses = mutableListOf<T>()
+            statuses.forEach { s ->
+                // TODO: 確実に最初の受信者だと分かるもののほうがよいかも DonStatusのfirstReceiverみたいな
+                if (s.url == newStatus.url && s.representUser == newStatus.representUser) {
+                    replaced = true
+                    newStatuses += newStatus
+                } else {
+                    newStatuses += s
+                }
+            }
+            if (!replaced) {
+                newStatuses += newStatus
+            }
+            return newStatuses
+        }
+    }
+}

--- a/Yukari/src/main/java/shibafu/yukari/entity/TimelineStatus.kt
+++ b/Yukari/src/main/java/shibafu/yukari/entity/TimelineStatus.kt
@@ -201,7 +201,7 @@ class TimelineStatus<T>(
                 val iterator = lefts.listIterator()
                 while (iterator.hasNext()) {
                     val given = iterator.next()
-                    if (exist.url == given.url && exist.representUser == given.representUser) {
+                    if (exist.url == given.url && exist.receiverUser == given.receiverUser) {
                         result += given
                         iterator.remove()
                         return@forEach

--- a/Yukari/src/main/java/shibafu/yukari/entity/TimelineStatus.kt
+++ b/Yukari/src/main/java/shibafu/yukari/entity/TimelineStatus.kt
@@ -23,6 +23,12 @@ class TimelineStatus<T>(
         lhs.compareMergePriorityTo(rhs).let { if (it != 0) return@sortedWith it }
         StatusComparator.BY_RECEIVER_ID.compare(lhs, rhs)
     }
+
+    /**
+     * 現在の代表ステータス。
+     *
+     * 表示用のプロパティなので、タイムラインの外にオブジェクトを持ち出す場合には [takeStatus] を呼び出す必要がある。
+     */
     val representStatus = this.statuses.first()
 
     override val id: Long
@@ -128,6 +134,9 @@ class TimelineStatus<T>(
         return representStatus.canFavorite(userRecord)
     }
 
+    /**
+     * 引数で与えた [Status] を取り込んだ、新しい [TimelineStatus] を作成する。既に取り込まれているステータスが指定された場合は、与えられたステータスで置き換える。
+     */
     fun merge(status: Status): Status {
         if (this === status) {
             return this
@@ -147,6 +156,15 @@ class TimelineStatus<T>(
 
         @Suppress("UNCHECKED_CAST")
         return TimelineStatus(upsertStatusBy(statuses, givenStatuses) as List<T>, prioritizedUser)
+    }
+
+    /**
+     * [representStatus] を単独で操作可能な状態にしてから取り出す。タイムライン外に持ち出す場合にはこのメソッドを呼び出す必要がある。
+     *
+     * このメソッドを呼び出しても、レシーバー内のコレクションからステータスは削除されない。
+     */
+    fun takeStatus(): Status {
+        return representStatus.unmerge(statuses.drop(1))
     }
 
     override fun getInReplyTo(): InReplyToId = _inReplyTo

--- a/Yukari/src/main/java/shibafu/yukari/entity/TimelineStatus.kt
+++ b/Yukari/src/main/java/shibafu/yukari/entity/TimelineStatus.kt
@@ -77,6 +77,15 @@ class TimelineStatus<T>(
 
     override var prioritizedUser: AuthUserRecord? = prioritizedUser ?: representStatus.prioritizedUser
 
+    override val receivedUsers: List<AuthUserRecord>
+        get() = sequence {
+            preferredOwnerUser?.let { yield(it) }
+            prioritizedUser?.let { yield(it) }
+            statuses.forEach { status ->
+                yield(status.receiverUser)
+            }
+        }.distinct().toList()
+
     private val _inReplyTo: InReplyToId by lazy {
         val inReplyTo = representStatus.getInReplyTo()
         statuses.drop(1).forEach { status ->

--- a/Yukari/src/main/java/shibafu/yukari/entity/TimelineStatus.kt
+++ b/Yukari/src/main/java/shibafu/yukari/entity/TimelineStatus.kt
@@ -91,7 +91,10 @@ class TimelineStatus<T>(
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
-        return representStatus.javaClass == other?.javaClass && representStatus == other
+        return when (other) {
+            is TimelineStatus<*> -> representStatus.javaClass == other.representStatus.javaClass && representStatus == other.representStatus
+            else -> representStatus.javaClass == other?.javaClass && representStatus == other
+        }
     }
 
     override fun hashCode(): Int {

--- a/Yukari/src/main/java/shibafu/yukari/fragment/status/StatusActionFragment.kt
+++ b/Yukari/src/main/java/shibafu/yukari/fragment/status/StatusActionFragment.kt
@@ -98,7 +98,7 @@ class StatusActionFragment : ListYukariBaseFragment(), AdapterView.OnItemClickLi
                 dialog.show(parentFragmentManager, "delete")
             } visibleWhen {
                 val status = status
-                status.user.id == userRecord?.NumericId || status is Bookmark
+                status.user.identicalUrl == userRecord?.IdenticalUrl || status is Bookmark
             },
 
             Action("通報する") {

--- a/Yukari/src/main/java/shibafu/yukari/fragment/tabcontent/BookmarkTimelineFragment.kt
+++ b/Yukari/src/main/java/shibafu/yukari/fragment/tabcontent/BookmarkTimelineFragment.kt
@@ -62,13 +62,9 @@ class BookmarkTimelineFragment : TimelineFragment(), CoroutineScope {
             status.setRepresentIfOwned(twitterService.users)
             if (!status.isOwnedStatus()) {
                 // 優先アカウント設定が存在するか？
-                val userExtras = userExtrasManager.userExtras.firstOrNull { it.id == status.originStatus.user.identicalUrl }
-                if (userExtras != null && userExtras.priorityAccount != null) {
-                    status.representUser = userExtras.priorityAccount
-                    status.representOverrode = true
-                    if (!status.receivedUsers.contains(userExtras.priorityAccount)) {
-                        status.receivedUsers.add(userExtras.priorityAccount)
-                    }
+                val priorityAccount = userExtrasManager.userExtras.firstOrNull { it.id == status.originStatus.user.identicalUrl }?.priorityAccount
+                if (priorityAccount != null) {
+                    status.setRepresentUserAndLock(priorityAccount)
                 }
             }
 

--- a/Yukari/src/main/java/shibafu/yukari/fragment/tabcontent/BookmarkTimelineFragment.kt
+++ b/Yukari/src/main/java/shibafu/yukari/fragment/tabcontent/BookmarkTimelineFragment.kt
@@ -64,7 +64,7 @@ class BookmarkTimelineFragment : TimelineFragment(), CoroutineScope {
                 // 優先アカウント設定が存在するか？
                 val priorityAccount = userExtrasManager.userExtras.firstOrNull { it.id == status.originStatus.user.identicalUrl }?.priorityAccount
                 if (priorityAccount != null) {
-                    status.setRepresentUserAndLock(priorityAccount)
+                    status.prioritizedUser = priorityAccount
                 }
             }
 

--- a/Yukari/src/main/java/shibafu/yukari/fragment/tabcontent/TimelineFragment.kt
+++ b/Yukari/src/main/java/shibafu/yukari/fragment/tabcontent/TimelineFragment.kt
@@ -255,7 +255,7 @@ open class TimelineFragment : ListYukariBaseFragment(),
             }.orEmpty()
 
             val result =
-                    when (val clickedElement = statuses[position]) {
+                    when (val clickedElement = statuses[position].let { if (it is TimelineStatus<*>) it.representStatus else it }) {
                         is LoadMarker -> {
                             if (clickedElement.taskKey < 0) {
                                 query.sources.firstOrNull { it.hashCode().toString() == clickedElement.loadMarkerTag }?.let {
@@ -354,7 +354,7 @@ open class TimelineFragment : ListYukariBaseFragment(),
             }.orEmpty()
 
             val result =
-                    when (val clickedElement = statuses[position]) {
+                    when (val clickedElement = statuses[position].let { if (it is TimelineStatus<*>) it.representStatus else it }) {
                         is TwitterStatus, is DonStatus, is Bookmark -> {
                             onGeneralItemClick(position, clickedElement, timelineClickAction())
                         }

--- a/Yukari/src/main/java/shibafu/yukari/fragment/tabcontent/TimelineFragment.kt
+++ b/Yukari/src/main/java/shibafu/yukari/fragment/tabcontent/TimelineFragment.kt
@@ -22,7 +22,6 @@ import android.widget.AdapterView
 import android.widget.ListView
 import android.widget.TextView
 import android.widget.Toast
-import org.eclipse.collections.impl.set.mutable.primitive.LongHashSet
 import shibafu.yukari.R
 import shibafu.yukari.activity.*
 import shibafu.yukari.common.TabType
@@ -55,7 +54,6 @@ import shibafu.yukari.util.AttrUtil
 import shibafu.yukari.util.defaultSharedPreferences
 import shibafu.yukari.util.putDebugLog
 import shibafu.yukari.util.putWarnLog
-import shibafu.yukari.view.TimelineErrorView
 import twitter4j.DirectMessage
 import twitter4j.TwitterException
 
@@ -770,13 +768,9 @@ open class TimelineFragment : ListYukariBaseFragment(),
         // 自身の所有するStatusの場合、書き換えてはいけない
         if (!status.isOwnedStatus()) {
             // 優先アカウント設定が存在するか？
-            val userExtras = userExtrasManager.userExtras.firstOrNull { it.id == status.originStatus.user.identicalUrl }
-            if (userExtras != null && userExtras.priorityAccount != null) {
-                status.representUser = userExtras.priorityAccount
-                status.representOverrode = true
-                if (!status.receivedUsers.contains(userExtras.priorityAccount)) {
-                    status.receivedUsers.add(userExtras.priorityAccount)
-                }
+            val priorityAccount = userExtrasManager.userExtras.firstOrNull { it.id == status.originStatus.user.identicalUrl }?.priorityAccount
+            if (priorityAccount != null) {
+                status.setRepresentUserAndLock(priorityAccount)
             }
         }
 

--- a/Yukari/src/main/java/shibafu/yukari/fragment/tabcontent/TimelineFragment.kt
+++ b/Yukari/src/main/java/shibafu/yukari/fragment/tabcontent/TimelineFragment.kt
@@ -787,7 +787,7 @@ open class TimelineFragment : ListYukariBaseFragment(),
                 // 優先アカウント設定が存在するか？
                 val priorityAccount = userExtrasManager.userExtras.firstOrNull { it.id == status.originStatus.user.identicalUrl }?.priorityAccount
                 if (priorityAccount != null) {
-                    status.setRepresentUserAndLock(priorityAccount)
+                    status.prioritizedUser = priorityAccount
                 }
             }
 

--- a/Yukari/src/main/java/shibafu/yukari/fragment/tabcontent/TimelineFragment.kt
+++ b/Yukari/src/main/java/shibafu/yukari/fragment/tabcontent/TimelineFragment.kt
@@ -255,7 +255,7 @@ open class TimelineFragment : ListYukariBaseFragment(),
             }.orEmpty()
 
             val result =
-                    when (val clickedElement = statuses[position].let { if (it is TimelineStatus<*>) it.representStatus else it }) {
+                    when (val clickedElement = statuses[position].let { if (it is TimelineStatus<*>) it.takeStatus() else it }) {
                         is LoadMarker -> {
                             if (clickedElement.taskKey < 0) {
                                 query.sources.firstOrNull { it.hashCode().toString() == clickedElement.loadMarkerTag }?.let {
@@ -354,7 +354,7 @@ open class TimelineFragment : ListYukariBaseFragment(),
             }.orEmpty()
 
             val result =
-                    when (val clickedElement = statuses[position].let { if (it is TimelineStatus<*>) it.representStatus else it }) {
+                    when (val clickedElement = statuses[position].let { if (it is TimelineStatus<*>) it.takeStatus() else it }) {
                         is TwitterStatus, is DonStatus, is Bookmark -> {
                             onGeneralItemClick(position, clickedElement, timelineClickAction())
                         }

--- a/Yukari/src/main/java/shibafu/yukari/mastodon/entity/DonStatus.kt
+++ b/Yukari/src/main/java/shibafu/yukari/mastodon/entity/DonStatus.kt
@@ -27,7 +27,7 @@ import shibafu.yukari.entity.Status as IStatus
 
 class DonStatus(val status: Status,
                 override var representUser: AuthUserRecord,
-                override val metadata: StatusPreforms = StatusPreforms()) : IStatus, Parcelable, PluginApplicable {
+                override val metadata: StatusPreforms = StatusPreforms()) : IStatus, MergeableStatus, Parcelable, PluginApplicable {
     override val id: Long
         get() = status.id
 
@@ -163,6 +163,11 @@ class DonStatus(val status: Status,
         return inReplyTo
     }
 
+    override fun compareMergePriorityTo(other: IStatus): Int {
+        if (other !is DonStatus) throw IllegalArgumentException()
+        return BY_LOCAL_STATUS.compare(this, other)
+    }
+
     fun checkProviderHostMismatching() {
         val localId = perProviderId[providerHost]
         if (id != localId) {
@@ -253,7 +258,6 @@ class DonStatus(val status: Status,
         metadata.isCensoredThumbs = status.isSensitive
     }
 
-    //<editor-fold desc="Parcelable">
     override fun describeContents(): Int = 0
 
     override fun writeToParcel(dest: Parcel, flags: Int) {
@@ -304,8 +308,9 @@ class DonStatus(val status: Status,
                 return arrayOfNulls(size)
             }
         }
+
+        private val BY_LOCAL_STATUS = Comparator.comparing<DonStatus, _> { !it.isLocal }
     }
-    //</editor-fold>
 
     class ProviderHostMismatchedException(expected: String, actual: String) : RuntimeException("[BUG] provider host mismatched!! expected = $expected, actual = $actual")
 }

--- a/Yukari/src/main/java/shibafu/yukari/mastodon/entity/DonStatus.kt
+++ b/Yukari/src/main/java/shibafu/yukari/mastodon/entity/DonStatus.kt
@@ -140,6 +140,18 @@ class DonStatus(val status: Status,
         return BY_LOCAL_STATUS.compare(this, other)
     }
 
+    override fun unmerge(followers: List<IStatus>): IStatus {
+        followers.forEach { status ->
+            if (status !is DonStatus) return@forEach
+            status.perProviderId.forEachKeyValue { key, value ->
+                if (!perProviderId.containsKey(key)) {
+                    perProviderId.put(key, value)
+                }
+            }
+        }
+        return this
+    }
+
     fun checkProviderHostMismatching() {
         val localId = perProviderId[providerHost]
         if (id != localId) {

--- a/Yukari/src/main/java/shibafu/yukari/twitter/entity/TwitterMessage.kt
+++ b/Yukari/src/main/java/shibafu/yukari/twitter/entity/TwitterMessage.kt
@@ -1,6 +1,5 @@
 package shibafu.yukari.twitter.entity
 
-import org.eclipse.collections.impl.factory.primitive.LongLists
 import shibafu.yukari.database.Provider
 import shibafu.yukari.entity.Mention
 import shibafu.yukari.entity.Status
@@ -17,7 +16,7 @@ import java.util.*
 class TwitterMessage(val message: DirectMessage,
                      val sender: twitter4j.User,
                      val recipient: twitter4j.User,
-                     override var representUser: AuthUserRecord) : Status {
+                     override var receiverUser: AuthUserRecord) : Status {
     override val id: Long
         get() = message.id
 
@@ -45,9 +44,9 @@ class TwitterMessage(val message: DirectMessage,
 
     override val tags: List<String> = message.hashtagEntities.map { it.text }
 
-    override var favoritesCount: Int = 0
+    override val favoritesCount: Int = 0
 
-    override var repostsCount: Int = 0
+    override val repostsCount: Int = 0
 
     override val metadata: StatusPreforms = StatusPreforms()
 
@@ -55,9 +54,9 @@ class TwitterMessage(val message: DirectMessage,
 
     override val providerHost: String = Provider.TWITTER.host
 
-    override var representOverrode: Boolean = false
+    override var preferredOwnerUser: AuthUserRecord? = null
 
-    override var receivedUsers: MutableList<AuthUserRecord> = arrayListOf(representUser)
+    override var prioritizedUser: AuthUserRecord? = null
 
     init {
         val media = LinkedHashSet<Media>()

--- a/Yukari/src/main/java/shibafu/yukari/twitter/entity/TwitterStatus.kt
+++ b/Yukari/src/main/java/shibafu/yukari/twitter/entity/TwitterStatus.kt
@@ -116,6 +116,10 @@ class TwitterStatus(val status: twitter4j.Status, override var receiverUser: Aut
         return 0
     }
 
+    override fun unmerge(followers: List<Status>): Status {
+        return this
+    }
+
     private val twitter4j.Status.originStatus: twitter4j.Status
         get() = if (this.isRetweet) this.retweetedStatus else this
 

--- a/Yukari/src/main/java/shibafu/yukari/twitter/entity/TwitterStatus.kt
+++ b/Yukari/src/main/java/shibafu/yukari/twitter/entity/TwitterStatus.kt
@@ -14,7 +14,7 @@ import java.util.*
 import java.util.regex.Pattern
 import kotlin.collections.LinkedHashSet
 
-class TwitterStatus(val status: twitter4j.Status, override var representUser: AuthUserRecord) : Status, PluginApplicable {
+class TwitterStatus(val status: twitter4j.Status, override var representUser: AuthUserRecord) : Status, MergeableStatus, PluginApplicable {
 
     override val id: Long = status.id
 
@@ -109,6 +109,10 @@ class TwitterStatus(val status: twitter4j.Status, override var representUser: Au
 
     override fun canFavorite(userRecord: AuthUserRecord): Boolean {
         return userRecord.Provider.apiType == Provider.API_TWITTER
+    }
+
+    override fun compareMergePriorityTo(other: Status): Int {
+        return 0
     }
 
     private val twitter4j.Status.originStatus: twitter4j.Status

--- a/Yukari/src/main/java/shibafu/yukari/twitter/entity/TwitterStatus.kt
+++ b/Yukari/src/main/java/shibafu/yukari/twitter/entity/TwitterStatus.kt
@@ -14,7 +14,7 @@ import java.util.*
 import java.util.regex.Pattern
 import kotlin.collections.LinkedHashSet
 
-class TwitterStatus(val status: twitter4j.Status, override var representUser: AuthUserRecord) : Status, MergeableStatus, PluginApplicable {
+class TwitterStatus(val status: twitter4j.Status, override var receiverUser: AuthUserRecord) : Status, MergeableStatus, PluginApplicable {
 
     override val id: Long = status.id
 
@@ -22,7 +22,8 @@ class TwitterStatus(val status: twitter4j.Status, override var representUser: Au
 
     override val text: String
 
-    override val recipientScreenName: String = representUser.ScreenName
+    override val recipientScreenName: String
+        get() = representUser.ScreenName
 
     override val createdAt: Date = status.createdAt
 
@@ -37,7 +38,7 @@ class TwitterStatus(val status: twitter4j.Status, override var representUser: Au
 
     override val isRepost: Boolean = status.isRetweet
 
-    override val originStatus: Status = if (isRepost) TwitterStatus(status.retweetedStatus, representUser) else this
+    override val originStatus: Status = if (isRepost) TwitterStatus(status.retweetedStatus, receiverUser) else this
 
     override val url: String = "https://twitter.com/${user.screenName}/status/$id"
 
@@ -51,9 +52,9 @@ class TwitterStatus(val status: twitter4j.Status, override var representUser: Au
 
     override val tags: List<String> = status.hashtagEntities.map { it.text }
 
-    override var favoritesCount: Int = status.originStatus.favoriteCount
+    override val favoritesCount: Int = status.originStatus.favoriteCount
 
-    override var repostsCount: Int = status.originStatus.retweetCount
+    override val repostsCount: Int = status.originStatus.retweetCount
 
     override val metadata: StatusPreforms = StatusPreforms()
 
@@ -61,9 +62,9 @@ class TwitterStatus(val status: twitter4j.Status, override var representUser: Au
 
     override val providerHost: String = Provider.TWITTER.host
 
-    override var representOverrode: Boolean = false
+    override var preferredOwnerUser: AuthUserRecord? = null
 
-    override var receivedUsers: MutableList<AuthUserRecord> = arrayListOf(representUser)
+    override var prioritizedUser: AuthUserRecord? = null
 
     override val isApplicablePlugin: Boolean
         get() = !user.isProtected


### PR DESCRIPTION
fix #252 

代表アカウントの概念と再決定処理は、何かと理解しづらいバグを起こしていた。

数年放置した末に「どれが代表アカウントなのはタイムラインごとに期待値が違う」「この辺りの可変性はStatus一般には求められておらず、タイムラインだけの都合である」という結論が出たので、Status interfaceからステータスマージと代表アカウントの再決定の概念を削除した。

代わりにTimelineStatusという新しいクラスを用意した。タイムライン上に挿入する前に、Statusをこのクラスでラップするような作りにした。ステータスマージの機能もこちらに移動している。

また、マージ時に実行していた代表アカウント再決定処理も大幅に変更し、判定に影響する変数が分かりやすいようにしている。