### PR TITLE
New ImageLoader

### DIFF
--- a/Yukari/src/main/java/shibafu/yukari/common/TweetAdapter.java
+++ b/Yukari/src/main/java/shibafu/yukari/common/TweetAdapter.java
@@ -10,7 +10,7 @@ import android.widget.BaseAdapter;
 import android.widget.ImageView;
 import android.widget.TextView;
 import shibafu.yukari.R;
-import shibafu.yukari.common.bitmapcache.ImageLoaderTask;
+import shibafu.yukari.common.imageloader.ImageLoader;
 import shibafu.yukari.database.Bookmark;
 import shibafu.yukari.database.UserExtras;
 import shibafu.yukari.entity.ExceptionStatus;
@@ -200,7 +200,7 @@ public class TweetAdapter extends BaseAdapter {
 
                 if (preferences.getBoolean("pref_show_load_more_user", false)) {
                     ivIcon.setVisibility(View.VISIBLE);
-                    ImageLoaderTask.loadProfileIcon(context, ivIcon, loadMarker.getRepresentUser().ProfileImageUrl);
+                    ImageLoader.INSTANCE.loadProfileIcon(context, loadMarker.getRepresentUser()).toImageView(ivIcon);
                 } else {
                     ivIcon.setVisibility(View.GONE);
                 }

--- a/Yukari/src/main/java/shibafu/yukari/common/bitmapcache/ImageLoaderTask.java
+++ b/Yukari/src/main/java/shibafu/yukari/common/bitmapcache/ImageLoaderTask.java
@@ -1,279 +1,64 @@
 package shibafu.yukari.common.bitmapcache;
 
 import android.content.Context;
-import android.content.SharedPreferences;
-import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
-import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
-import android.os.AsyncTask;
-import android.os.Build;
+import android.widget.ImageView;
+
 import androidx.annotation.IntDef;
 import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.preference.PreferenceManager;
 
-import android.widget.ImageView;
-import shibafu.yukari.R;
 import shibafu.yukari.common.bitmapcache.BitmapCache.CacheKey;
+import shibafu.yukari.common.imageloader.ImageLoader;
+import shibafu.yukari.common.imageloader.ImageLoaderResultCallback;
+import shibafu.yukari.common.imageloader.ResolveMode;
 import shibafu.yukari.media2.Media;
-import shibafu.yukari.util.BitmapUtil;
-
-import java.io.BufferedInputStream;
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.lang.ref.WeakReference;
-import java.net.URL;
-import java.util.concurrent.Executor;
-import java.util.concurrent.Executors;
-import java.util.concurrent.RejectedExecutionException;
 
 /**
  * Created by Shibafu on 13/10/28.
  */
-public class ImageLoaderTask extends AsyncTask<ImageLoaderTask.Params, Void, Bitmap> {
+public final class ImageLoaderTask {
     public static final int RESOLVE_MEDIA = 0;
     public static final int RESOLVE_THUMBNAIL = 1;
 
-    /** 一般の画像用 */
-    private static final Executor IMAGE_EXECUTOR = THREAD_POOL_EXECUTOR;
-    /** プロフィールアイコン用 */
-    private static final Executor PROFILE_ICON_EXECUTOR = Executors.newFixedThreadPool(4);
-
-    private Context context;
-    private final SharedPreferences sharedPreferences;
-    private WeakReference<ImageView> imageViewRef;
-    private String tag;
-
-    private ImageLoaderTask(Context context, ImageView imageView) {
-        this.context = context;
-        sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context);
-        imageViewRef = new WeakReference<>(imageView);
-        if (imageView != null) {
-            tag = imageView.getTag().toString();
-        }
-    }
-
-    @Override
-    protected Bitmap doInBackground(Params... params) {
-        final Params param = params[0];
-        if (context == null) return null;
-        try {
-            Bitmap image = BitmapCache.getImageFromDisk(param.url, param.cacheKey, context);
-            //無かったらWebから取得だ！
-            if (image == null) {
-                if (sharedPreferences.getBoolean("pref_indicate_loading_from_remote", false)) {
-                    publishProgress();
-                }
-
-                Media.ResolveInfo resolveInfo = null;
-                InputStream inputStream;
-                if (param.media == null) {
-                    // Mediaが設定されていない場合は実体解決処理は行わずURLに直接接続する
-                    inputStream = new URL(param.url).openStream();
-                } else {
-                    switch (param.resolveMode) {
-                        case RESOLVE_MEDIA:
-                            resolveInfo = param.media.resolveMedia();
-                            break;
-                        case RESOLVE_THUMBNAIL:
-                            resolveInfo = param.media.resolveThumbnail();
-                            break;
-                    }
-                    if (resolveInfo == null) {
-                        throw new FileNotFoundException("Resolve failed : " + param.media.getBrowseUrl());
-                    }
-                    inputStream = resolveInfo.getStream();
-                }
-
-                File tempFile = File.createTempFile("image", ".tmp", context.getExternalCacheDir());
-                try {
-                    BufferedInputStream is = new BufferedInputStream(inputStream);
-                    FileOutputStream fos = new FileOutputStream(tempFile);
-                    try {
-                        byte[] buffer = new byte[4096];
-                        int length;
-                        while ((length = is.read(buffer, 0, buffer.length)) != -1) {
-                            fos.write(buffer, 0, length);
-                        }
-                    } finally {
-                        fos.close();
-                        is.close();
-                    }
-                    BitmapFactory.Options options = new BitmapFactory.Options();
-                    options.inJustDecodeBounds = true;
-                    BitmapFactory.decodeFile(tempFile.getAbsolutePath(), options);
-                    options.inSampleSize = Math.max(options.outWidth / 512, options.outHeight / 512);
-                    options.inJustDecodeBounds = false;
-                    options.inPreferredConfig = Bitmap.Config.ARGB_8888;
-                    image = BitmapFactory.decodeFile(tempFile.getAbsolutePath(), options);
-                } finally {
-                    tempFile.delete();
-                    if (resolveInfo != null) {
-                        resolveInfo.dispose();
-                    }
-                }
-                //キャッシュに保存
-                BitmapCache.putImage(param.url, image, context, param.cacheKey, !param.mosaic, true);
-            }
-            if (image != null && param.mosaic) {
-                image = BitmapUtil.createMosaic(image);
-                BitmapCache.putImage(generateCacheUrlForMosaic(param.url), image, context, param.cacheKey, true, false);
-            }
-            return image;
-        } catch (IOException e) {
-            e.printStackTrace();
-        }
-        return null;
-    }
-
-    private ImageView getImageViewInstance() {
-        if (imageViewRef != null) {
-            ImageView iv = imageViewRef.get();
-            if (iv != null && tag.equals(iv.getTag())) {
-                return iv;
-            }
-        }
-        return null;
-    }
-
-    @Override
-    protected void onProgressUpdate(Void... values) {
-        ImageView imageView = getImageViewInstance();
-        if (imageView != null) {
-            imageView.setImageResource(R.drawable.loading_from_remote);
-        }
-    }
-
-    @Override
-    protected void onPostExecute(Bitmap bitmap) {
-        ImageView imageView = getImageViewInstance();
-        if (imageView != null) {
-            if (bitmap != null) {
-                imageView.setImageBitmap(bitmap);
-            }
-            else {
-                imageView.setImageResource(R.drawable.ic_states_warning);
-            }
-        }
-    }
-
-    public void executeWrapper(Executor executor, Params params) {
-        if (getStatus() == Status.RUNNING && !isCancelled()) return;
-        try {
-            this.executeOnExecutor(executor, params);
-        } catch (RejectedExecutionException e) {
-            executeWrapper(executor, params);
-        }
-    }
-
     public static void loadProfileIcon(Context context, ImageView imageView, String uri) {
-        loadBitmap(context, imageView, uri, RESOLVE_MEDIA, BitmapCache.PROFILE_ICON_CACHE, false);
+        ImageLoader.INSTANCE.load(context, uri)
+                .setCacheGroup(BitmapCache.PROFILE_ICON_CACHE)
+                .toImageView(imageView);
     }
 
     public static void loadBitmap(Context context, ImageView imageView, String uri) {
-        loadBitmap(context, imageView, uri, RESOLVE_MEDIA, BitmapCache.IMAGE_CACHE, false);
+        ImageLoader.INSTANCE.load(context, uri)
+                .setCacheGroup(BitmapCache.IMAGE_CACHE)
+                .toImageView(imageView);
     }
 
-    public static void loadBitmap(Context context, ImageView imageView, Media media, @ResolveMode int resolveMode, @CacheKey String cacheKey, boolean mosaic) {
-        if (media == null) {
-            imageView.setImageResource(R.drawable.ic_states_warning);
-            return;
-        }
-
-        imageView.setTag(media.getBrowseUrl());
-        Bitmap cache;
-        if (mosaic) {
-            cache = BitmapCache.getImageFromMemory(generateCacheUrlForMosaic(media.getBrowseUrl()), cacheKey);
-        } else {
-            cache = BitmapCache.getImageFromMemory(media.getBrowseUrl(), cacheKey);
-        }
-        if (cache != null && !cache.isRecycled()) {
-            imageView.setImageBitmap(cache);
-        } else {
-            imageView.setImageResource(R.drawable.yukatterload);
-            new ImageLoaderTask(context, imageView).executeWrapper(
-                    BitmapCache.IMAGE_CACHE.equals(cacheKey) ? IMAGE_EXECUTOR : PROFILE_ICON_EXECUTOR,
-                    new Params(resolveMode, cacheKey, mosaic, media));
-        }
-    }
-
-    // fast-path mode (for Profile Icon)
-    public static void loadBitmap(Context context, ImageView imageView, String uri, @ResolveMode int resolveMode, @CacheKey String cacheKey, boolean mosaic) {
-        if (uri == null) {
-            imageView.setImageResource(R.drawable.ic_states_warning);
-            return;
-        }
-
-        imageView.setTag(uri);
-        Bitmap cache;
-        if (mosaic) {
-            cache = BitmapCache.getImageFromMemory(generateCacheUrlForMosaic(uri), cacheKey);
-        } else {
-            cache = BitmapCache.getImageFromMemory(uri, cacheKey);
-        }
-        if (cache != null && !cache.isRecycled()) {
-            imageView.setImageBitmap(cache);
-        } else {
-            imageView.setImageResource(R.drawable.yukatterload);
-            new ImageLoaderTask(context, imageView).executeWrapper(
-                    BitmapCache.IMAGE_CACHE.equals(cacheKey) ? IMAGE_EXECUTOR : PROFILE_ICON_EXECUTOR,
-                    new Params(resolveMode, cacheKey, mosaic, uri));
-        }
+    public static void loadBitmap(Context context, ImageView imageView, Media media, @LegacyResolveMode int resolveMode, @CacheKey String cacheKey, boolean mosaic) {
+        ImageLoader.INSTANCE.load(context, media)
+                .setResolveMode(resolveMode == RESOLVE_MEDIA ? ResolveMode.MEDIA : ResolveMode.THUMBNAIL)
+                .setCacheGroup(cacheKey)
+                .setMosaic(mosaic)
+                .toImageView(imageView);
     }
 
     public static void loadDrawable(final Context context, String uri, @CacheKey String mode, final DrawableLoaderCallback callback) {
-        Bitmap cache = BitmapCache.getImageFromMemory(uri, mode);
-        if (cache != null && !cache.isRecycled()) {
-            callback.onLoadDrawable(new BitmapDrawable(context.getResources(), cache));
-        } else {
-            new ImageLoaderTask(context, null) {
-                @Override
-                protected void onPostExecute(Bitmap bitmap) {
-                    callback.onLoadDrawable(new BitmapDrawable(context.getResources(), bitmap));
-                }
-            }.executeWrapper(
-                    BitmapCache.IMAGE_CACHE.equals(mode) ? IMAGE_EXECUTOR : PROFILE_ICON_EXECUTOR,
-                    new Params(RESOLVE_MEDIA, mode, false, uri));
-        }
-    }
+        ImageLoader.INSTANCE.load(context, uri)
+                .setResolveMode(ResolveMode.MEDIA)
+                .setCacheGroup(mode)
+                .asDrawable(new ImageLoaderResultCallback<Drawable>() {
+                    @Override
+                    public void onSuccess(Drawable drawable) {
+                        callback.onLoadDrawable(drawable);
+                    }
 
-    private static String generateCacheUrlForMosaic(String url) {
-        return "[mosaic]" + url;
+                    @Override
+                    public void onFailure(@NonNull Throwable e) {}
+                }, null, null);
     }
 
     public interface DrawableLoaderCallback {
         void onLoadDrawable(Drawable drawable);
     }
 
-    static class Params {
-        @ResolveMode public final int resolveMode;
-        @CacheKey public final String cacheKey;
-        public final boolean mosaic;
-
-        @Nullable public final Media media; // if null -> fast-path mode!
-        public final String url;
-
-        private Params(@ResolveMode int resolveMode, @CacheKey String cacheKey, boolean mosaic, @NonNull Media media) {
-            this.resolveMode = resolveMode;
-            this.cacheKey = cacheKey;
-            this.mosaic = mosaic;
-            this.media = media;
-            this.url = media.getBrowseUrl();
-        }
-
-        private Params(@ResolveMode int resolveMode, @CacheKey String cacheKey, boolean mosaic, @NonNull String url) {
-            this.resolveMode = resolveMode;
-            this.cacheKey = cacheKey;
-            this.mosaic = mosaic;
-            this.url = url;
-            this.media = null;
-        }
-    }
-
     @IntDef({RESOLVE_MEDIA, RESOLVE_THUMBNAIL})
-    public @interface ResolveMode {}
+    public @interface LegacyResolveMode {}
 }

--- a/Yukari/src/main/java/shibafu/yukari/common/imageloader/ImageLoader.kt
+++ b/Yukari/src/main/java/shibafu/yukari/common/imageloader/ImageLoader.kt
@@ -11,6 +11,7 @@ import android.widget.ImageView
 import androidx.annotation.NonUiContext
 import androidx.core.os.HandlerCompat
 import androidx.preference.PreferenceManager
+import com.google.common.util.concurrent.ThreadFactoryBuilder
 import shibafu.yukari.R
 import shibafu.yukari.common.bitmapcache.BitmapCache
 import shibafu.yukari.common.bitmapcache.BitmapCache.CacheKey
@@ -288,9 +289,9 @@ class ImageLoaderTask(
         private val numberOfCores = Runtime.getRuntime().availableProcessors()
 
         /** 通常使用するExecutor */
-        val imageExecutor: ExecutorService = Executors.newFixedThreadPool(numberOfCores)
+        val imageExecutor: ExecutorService = Executors.newFixedThreadPool(numberOfCores, ThreadFactoryBuilder().setNameFormat("ImageLoader-i%d").build())
         /** プロフィール画像取得タスク専用のExecutor */
-        val profileIconExecutor: ExecutorService = Executors.newFixedThreadPool(4)
+        val profileIconExecutor: ExecutorService = Executors.newFixedThreadPool(4, ThreadFactoryBuilder().setNameFormat("ImageLoader-p%d").build())
 
         private val mainThreadHandler = HandlerCompat.createAsync(Looper.getMainLooper())
     }

--- a/Yukari/src/main/java/shibafu/yukari/common/imageloader/ImageLoader.kt
+++ b/Yukari/src/main/java/shibafu/yukari/common/imageloader/ImageLoader.kt
@@ -1,0 +1,282 @@
+package shibafu.yukari.common.imageloader
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.drawable.BitmapDrawable
+import android.graphics.drawable.Drawable
+import android.os.Looper
+import android.widget.ImageView
+import androidx.annotation.NonUiContext
+import androidx.core.os.HandlerCompat
+import androidx.preference.PreferenceManager
+import shibafu.yukari.R
+import shibafu.yukari.common.bitmapcache.BitmapCache
+import shibafu.yukari.common.bitmapcache.BitmapCache.CacheKey
+import shibafu.yukari.entity.User
+import shibafu.yukari.media2.Media
+import shibafu.yukari.util.BitmapUtil
+import java.io.File
+import java.io.FileNotFoundException
+import java.lang.ref.WeakReference
+import java.net.URL
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+import kotlin.math.max
+
+object ImageLoader {
+    fun load(@NonUiContext context: Context, url: String) = ImageLoaderTaskBuilder(context, url)
+
+    fun load(@NonUiContext context: Context, media: Media) = ImageLoaderTaskBuilder(context, media)
+
+    fun loadProfileIcon(@NonUiContext context: Context, user: User, preferBiggerImage: Boolean) = when {
+        preferBiggerImage -> load(context, user.biggerProfileImageUrl)
+        else -> load(context, user.profileImageUrl)
+    }.setCacheKey(user.url!!).setCacheGroup(BitmapCache.PROFILE_ICON_CACHE)
+}
+
+enum class ResolveMode {
+    /** [Media.resolveMedia] を使って画像を取得 */
+    MEDIA,
+    /** [Media.resolveThumbnail] を使って画像を取得 */
+    THUMBNAIL,
+}
+
+/**
+ * [ImageLoaderTask] の結果を受け取るためのコールバック。Java互換用。
+ */
+interface ImageLoaderResultCallback<T> {
+    fun onSuccess(value: T)
+    fun onFailure(e: Throwable)
+}
+
+class ImageLoaderTaskBuilder {
+    @NonUiContext private val context: Context
+    private val url: String
+    private val media: Media?
+    private var resolveMode: ResolveMode = ResolveMode.MEDIA
+    @CacheKey private var cacheGroup: String = BitmapCache.IMAGE_CACHE
+    private var cacheKey: String
+    private var mosaic: Boolean = false
+
+    constructor(@NonUiContext context: Context, url: String) {
+        this.context = context.applicationContext
+        this.url = url
+        this.media = null
+        this.cacheKey = url
+    }
+
+    constructor(@NonUiContext context: Context, media: Media) {
+        this.context = context.applicationContext
+        this.url = media.browseUrl
+        this.media = media
+        this.cacheKey = media.browseUrl
+    }
+
+    // setter
+
+    /**
+     * [Media]をどのように解決するかを指定
+     */
+    fun setResolveMode(resolveMode: ResolveMode) = also { it.resolveMode = resolveMode }
+
+    /**
+     * 容量クォータを共有するグループ名を指定 ([BitmapCache]クラスでは _cacheKey_ と呼ばれているもの)
+     */
+    fun setCacheGroup(@CacheKey cacheGroup: String) = also { it.cacheGroup = cacheGroup }
+
+    /**
+     * キャッシュを読み書きする際に使うキーを指定 ([BitmapCache]クラスでは _key_ と呼ばれているもの)
+     */
+    fun setCacheKey(cacheKey: String) = also { it.cacheKey = cacheKey }
+
+    /**
+     * モザイクフィルタを適用する
+     */
+    fun setMosaic(mosaic: Boolean) = also { it.mosaic = mosaic }
+
+    // sink
+
+    /**
+     * 読み込みを開始し、結果を [Bitmap] として受け取る
+     */
+    fun asBitmap(onFinish: (result: Result<Bitmap>) -> Unit, onQueue: (() -> Unit)? = null, onDownloadStart: (() -> Unit)? = null) {
+        // TODO: nullableにするかどうか迷いがある。受け入れる理由はないが、Javaから呼ばれるので...
+        if (url == null) {
+            onFinish(Result.failure(IllegalArgumentException("resource is null")))
+            return
+        }
+
+        val cache = when (mosaic) {
+            true -> BitmapCache.getImageFromMemory(mosaicCacheKey(cacheKey), cacheGroup)
+            false -> BitmapCache.getImageFromMemory(cacheKey, cacheGroup)
+        }
+        if (cache != null && !cache.isRecycled) {
+            onFinish(Result.success(cache))
+            return
+        }
+
+        onQueue?.invoke()
+        val task = ImageLoaderTask(context, url, media, resolveMode, cacheGroup, cacheKey, mosaic, onDownloadStart, onFinish)
+        if (cacheGroup == BitmapCache.PROFILE_ICON_CACHE) {
+            ImageLoaderTask.profileIconExecutor.execute(task) // TODO: submitならFutureが返る そっちを使うべきか?
+        } else {
+            ImageLoaderTask.imageExecutor.execute(task)
+        }
+    }
+
+    fun asBitmap(onFinish: ImageLoaderResultCallback<Bitmap>, onQueue: (() -> Unit)?, onDownloadStart: (() -> Unit)?) {
+        asBitmap({ result -> result.onSuccess(onFinish::onSuccess).onFailure(onFinish::onFailure) }, onQueue, onDownloadStart)
+    }
+
+    /**
+     * 読み込みを開始し、結果を [Drawable] として受け取る
+     */
+    fun asDrawable(onFinish: (result: Result<Drawable>) -> Unit, onQueue: (() -> Unit)? = null, onDownloadStart: (() -> Unit)? = null) {
+        asBitmap({ onFinish(it.map(::bitmapToDrawable)) }, onQueue, onDownloadStart)
+    }
+
+    fun asDrawable(onFinish: ImageLoaderResultCallback<Drawable>, onQueue: (() -> Unit)?, onDownloadStart: (() -> Unit)?) {
+        asBitmap({ result -> result.onSuccess(::bitmapToDrawable).onFailure(onFinish::onFailure) }, onQueue, onDownloadStart)
+    }
+
+    private fun bitmapToDrawable(bitmap: Bitmap) = BitmapDrawable(context.resources, bitmap)
+
+    /**
+     * 読み込みを開始し、結果を引数で指定した [ImageView] にセットする
+     */
+    fun toImageView(imageView: ImageView) {
+        imageView.tag = cacheKey
+        toImageView(WeakReference(imageView)) // ImageViewのリークを回避するために弱参照化
+    }
+
+    private fun toImageView(imageViewRef: WeakReference<ImageView>) {
+        val sp = PreferenceManager.getDefaultSharedPreferences(context)
+
+        asBitmap(
+            onQueue = {
+                val iv = imageViewRef.get() ?: return@asBitmap
+                if (cacheKey == iv.tag) {
+                    iv.setImageResource(R.drawable.yukatterload)
+                }
+            },
+            onDownloadStart = {
+                val iv = imageViewRef.get() ?: return@asBitmap
+                if (cacheKey == iv.tag && sp.getBoolean("pref_indicate_loading_from_remote", false)) {
+                    iv.setImageResource(R.drawable.loading_from_remote)
+                }
+            },
+            onFinish = { result ->
+                val iv = imageViewRef.get() ?: return@asBitmap
+                result.onSuccess { bitmap ->
+                    if (cacheKey == iv.tag) {
+                        iv.setImageBitmap(bitmap)
+                    }
+                }.onFailure {
+                    it.printStackTrace()
+                    iv.setImageResource(R.drawable.ic_states_warning)
+                }
+            }
+        )
+    }
+}
+
+class ImageLoaderTask(
+    @NonUiContext private val context: Context,
+    private val url: String,
+    private val media: Media?,
+    private val resolveMode: ResolveMode,
+    @CacheKey private val cacheGroup: String,
+    private val cacheKey: String,
+    private val mosaic: Boolean,
+    private val onDownloadStart: (() -> Unit)?,
+    private val onFinish: (result: Result<Bitmap>) -> Unit,
+) : Runnable {
+    override fun run() {
+        try {
+            val image = load()
+            mainThreadHandler.post { onFinish(Result.success(image)) }
+        } catch (e: Exception) {
+            mainThreadHandler.post { onFinish(Result.failure(e)) }
+        }
+    }
+
+    private fun load(): Bitmap {
+        val image = BitmapCache.getImageFromDisk(cacheKey, cacheGroup, context) ?: fetch() ?: throw NullBitmapException()
+        if (mosaic) {
+            val mosaicImage = BitmapUtil.createMosaic(image)
+            BitmapCache.putImage(
+                mosaicCacheKey(cacheKey),
+                mosaicImage,
+                context,
+                cacheGroup,
+                true,
+                false
+            )
+            return mosaicImage
+        }
+        return image
+    }
+
+    private fun fetch(): Bitmap? {
+        onDownloadStart?.let { callback -> mainThreadHandler.post(callback) }
+
+        var resolveInfo: Media.ResolveInfo? = null
+        val inputStream = if (media == null) {
+            URL(url).openStream()
+        } else {
+            resolveInfo = when (resolveMode) {
+                ResolveMode.MEDIA -> media.resolveMedia()
+                ResolveMode.THUMBNAIL -> media.resolveThumbnail()
+            }
+            if (resolveInfo == null) {
+                throw FileNotFoundException("Resolve failed: ${media.browseUrl}")
+            }
+            resolveInfo.stream
+        }
+
+        val tempFile = File.createTempFile("image", ".tmp", context.externalCacheDir)
+        try {
+            inputStream.buffered().use { bis ->
+                tempFile.outputStream().use { fos ->
+                    bis.copyTo(fos)
+                }
+            }
+
+            val options = BitmapFactory.Options()
+            options.inJustDecodeBounds = true
+            BitmapFactory.decodeFile(tempFile.absolutePath, options)
+            options.inSampleSize = max(options.outWidth / 512, options.outHeight / 512)
+            options.inJustDecodeBounds = false
+            options.inPreferredConfig = Bitmap.Config.ARGB_8888
+
+            val image = BitmapFactory.decodeFile(tempFile.absolutePath, options)
+            if (image != null) {
+                BitmapCache.putImage(cacheKey, image, context, cacheGroup, !mosaic, true)
+            }
+
+            return image
+        } finally {
+            tempFile.delete()
+            resolveInfo?.dispose()
+        }
+    }
+
+    companion object {
+        private val numberOfCores = Runtime.getRuntime().availableProcessors()
+
+        /** 通常使用するExecutor */
+        val imageExecutor: ExecutorService = Executors.newFixedThreadPool(numberOfCores)
+        /** プロフィール画像取得タスク専用のExecutor */
+        val profileIconExecutor: ExecutorService = Executors.newFixedThreadPool(4)
+
+        private val mainThreadHandler = HandlerCompat.createAsync(Looper.getMainLooper())
+    }
+}
+
+/**
+ * ダウンロード、またはキャッシュから取得した画像を [BitmapFactory] でデコードした結果、nullが返された時に発生する例外
+ */
+class NullBitmapException : Exception("BitmapFactory returned null reference")
+
+private fun mosaicCacheKey(key: String) = "[mosaic]$key"

--- a/Yukari/src/main/java/shibafu/yukari/common/imageloader/TaskManager.kt
+++ b/Yukari/src/main/java/shibafu/yukari/common/imageloader/TaskManager.kt
@@ -1,6 +1,7 @@
 package shibafu.yukari.common.imageloader
 
 import android.graphics.Bitmap
+import com.google.common.util.concurrent.ThreadFactoryBuilder
 import shibafu.yukari.common.bitmapcache.BitmapCache
 import shibafu.yukari.common.bitmapcache.BitmapCache.CacheKey
 import java.util.concurrent.ConcurrentHashMap
@@ -9,7 +10,7 @@ import java.util.concurrent.TimeUnit
 
 object TaskManager {
     private val tasks = ConcurrentHashMap<TaskKey, TaskState>()
-    private val evictExecutor = Executors.newSingleThreadScheduledExecutor()
+    private val evictExecutor = Executors.newSingleThreadScheduledExecutor(ThreadFactoryBuilder().setNameFormat("ImageLoader-e%d").build())
 
     fun subscribe(task: ImageLoaderTask) {
         tasks.getOrPut(task.key) { TaskState(task) }.subscribe(task)

--- a/Yukari/src/main/java/shibafu/yukari/common/imageloader/TaskManager.kt
+++ b/Yukari/src/main/java/shibafu/yukari/common/imageloader/TaskManager.kt
@@ -1,0 +1,74 @@
+package shibafu.yukari.common.imageloader
+
+import android.graphics.Bitmap
+import shibafu.yukari.common.bitmapcache.BitmapCache
+import shibafu.yukari.common.bitmapcache.BitmapCache.CacheKey
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+object TaskManager {
+    private val tasks = ConcurrentHashMap<TaskKey, TaskState>()
+    private val evictExecutor = Executors.newSingleThreadScheduledExecutor()
+
+    fun subscribe(task: ImageLoaderTask) {
+        tasks.getOrPut(task.key) { TaskState(task) }.subscribe(task)
+    }
+
+    fun scheduleEvict(key: TaskKey) {
+        evictExecutor.schedule({ tasks.remove(key) }, 5, TimeUnit.SECONDS)
+    }
+}
+
+data class TaskKey(@CacheKey val cacheGroup: String, val cacheKey: String, val mosaic: Boolean)
+
+class TaskState(task: ImageLoaderTask) {
+    private var isDownloadStarted = false
+    private var result: Result<Bitmap>? = null
+
+    private val onDownloadStartListeners = arrayListOf<(() -> Unit)?>()
+    private val onFinishListeners = arrayListOf<(Result<Bitmap>) -> Unit>()
+
+    init {
+        val key = task.key
+        val newTask = ImageLoaderTask(
+            task,
+            onDownloadStart = {
+                synchronized(onDownloadStartListeners) {
+                    isDownloadStarted = true
+                    onDownloadStartListeners.forEach { it?.invoke() }
+                }
+            },
+            onFinish = { result ->
+                synchronized(onFinishListeners) {
+                    this.result = result
+                    onFinishListeners.forEach { it.invoke(result) }
+                }
+                TaskManager.scheduleEvict(key)
+            },
+        )
+        if (key.cacheGroup == BitmapCache.PROFILE_ICON_CACHE) {
+            ImageLoaderTask.profileIconExecutor.execute(newTask)
+        } else {
+            ImageLoaderTask.imageExecutor.execute(newTask)
+        }
+    }
+
+    fun subscribe(task: ImageLoaderTask) {
+        synchronized(onDownloadStartListeners) {
+            if (isDownloadStarted) {
+                task.onDownloadStart?.invoke()
+            } else {
+                onDownloadStartListeners.add(task.onDownloadStart)
+            }
+        }
+        synchronized(onFinishListeners) {
+            val result = result
+            if (result != null) {
+                task.onFinish(result)
+            } else {
+                onFinishListeners.add(task.onFinish)
+            }
+        }
+    }
+}

--- a/Yukari/src/main/java/shibafu/yukari/view/StatusView.kt
+++ b/Yukari/src/main/java/shibafu/yukari/view/StatusView.kt
@@ -29,6 +29,7 @@ import shibafu.yukari.activity.PreviewActivity2
 import shibafu.yukari.common.FontAsset
 import shibafu.yukari.common.bitmapcache.BitmapCache
 import shibafu.yukari.common.bitmapcache.ImageLoaderTask
+import shibafu.yukari.common.imageloader.ImageLoader
 import shibafu.yukari.database.UserExtras
 import shibafu.yukari.entity.Status
 import shibafu.yukari.linkage.TimelineHubImpl
@@ -215,9 +216,7 @@ abstract class StatusView : RelativeLayout {
         val status = status ?: return
         val user = status.originStatus.user
 
-        if (ivIcon.tag == null || ivIcon.tag != user.biggerProfileImageUrl) {
-            ImageLoaderTask.loadProfileIcon(context, ivIcon, user.biggerProfileImageUrl)
-        }
+        ImageLoader.loadProfileIcon(context, user, true).toImageView(ivIcon)
 
         val onTouchProfileImageIconListener = onTouchProfileImageIconListener
         if (onTouchProfileImageIconListener != null) {
@@ -275,9 +274,7 @@ abstract class StatusView : RelativeLayout {
                 setBackgroundResource(bgRetweetResId)
 
                 ivRetweeterIcon.visibility = View.VISIBLE
-                ImageLoaderTask.loadProfileIcon(context,
-                        ivRetweeterIcon,
-                        status.user.biggerProfileImageUrl)
+                ImageLoader.loadProfileIcon(context, status.user, true).toImageView(ivRetweeterIcon)
             } else {
                 ivRetweeterIcon.visibility = View.INVISIBLE
                 ivRetweeterIcon.setImageDrawable(ColorDrawable(Color.TRANSPARENT))


### PR DESCRIPTION
新しいImageLoaderを作成し、既存のImageLoaderTaskを置き換えた。  
なお、ImageLoaderTaskクラス自体は残していて、全て新しい実装を呼び出すようになっている。

## 動機
- ImageLoaderTaskは非推奨APIのAsyncTaskベースだったこと
- APIが分かりにくく、汎用性も低い
- キャッシュキーをカスタマイズする手段が無かった

## 改善点
- AsyncTaskへの依存を排除し、非同期処理自体は普通のRunnableになった
- 既存APIのユースケースを整理して、よくある入力引数のパターンを簡潔に書けるようにした
- APIにBuliderパターンを採用し、リクエストをカスタマイズしやすくした
- 結果をImageViewに反映する以外に、コールバックで受け取れるようにして汎用性を上げた
- 同じキャッシュキーに対する非同期ロードを1つのタスクに集約し、タスクキューの長さとキャッシュミス時のHTTPリクエストの回数を削減した
