### PR TITLE
.tmpで終わる一時ファイルを削除する時、1日以上経過した古いものだけ削除するようにした

### DIFF
--- a/Yukari/src/main/java/shibafu/yukari/service/CacheCleanerService.java
+++ b/Yukari/src/main/java/shibafu/yukari/service/CacheCleanerService.java
@@ -62,7 +62,12 @@ public class CacheCleanerService extends JobIntentService {
             expirations.addAll(findExpirationCaches(new File(cacheRoot, categories[i]), limits[i] * 1024 * 1024));
         }
         File[] tmpFiles = getExternalCacheDir().listFiles((dir, filename) -> filename.endsWith(".tmp"));
-        expirations.addAll(Arrays.asList(tmpFiles));
+        long currentTimeMillis = System.currentTimeMillis();
+        for (File tmpFile : tmpFiles) {
+            if (tmpFile.lastModified() < currentTimeMillis - 86400000) {
+                expirations.add(tmpFile);
+            }
+        }
 
         for (File f : expirations) {
             Log.d("CacheCleanerService", "Deleting: " + f.getAbsolutePath());


### PR DESCRIPTION
fix #352 

CacheCleanerService、元々はこんな頻度で起動されると思っていなかったので処理中に割り込まれてる事が想定されていなかった。

ひとまず、mtimeが1日経過していないものは削除しないようにした。そもそもこれらのファイルを作る処理が正常終了していれば削除されているはずなので、そんなに急いで削除して回る必要はない。