### PR TITLE
CacheCleanerServiceをJobIntentServiceからWorkManager Workerに置き換え

### DIFF
--- a/Yukari/build.gradle
+++ b/Yukari/build.gradle
@@ -169,6 +169,7 @@ dependencies {
     implementation 'androidx.browser:browser:1.5.0'
     implementation 'androidx.collection:collection:1.5.0'
     implementation 'androidx.lifecycle:lifecycle-process:2.6.2'
+    implementation 'androidx.work:work-runtime-ktx:2.8.1'
 
     def lifecycle_version = '2.5.1'
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version"

--- a/Yukari/src/main/AndroidManifest.xml
+++ b/Yukari/src/main/AndroidManifest.xml
@@ -78,10 +78,6 @@
         </activity>
 
         <service android:name=".service.AsyncCommandService"/>
-        <service
-            android:name=".service.CacheCleanerService"
-            android:permission="android.permission.BIND_JOB_SERVICE"
-            android:process=":cleaner"/>
 
         <activity
             android:name="shibafu.yukari.activity.TweetActivity"

--- a/Yukari/src/main/java/shibafu/yukari/common/JobSchedulerId.java
+++ b/Yukari/src/main/java/shibafu/yukari/common/JobSchedulerId.java
@@ -1,5 +1,0 @@
-package shibafu.yukari.common;
-
-public final class JobSchedulerId {
-    public static final int JOB_CACHE_CLEANER = 1;
-}

--- a/Yukari/src/main/java/shibafu/yukari/core/App.kt
+++ b/Yukari/src/main/java/shibafu/yukari/core/App.kt
@@ -54,7 +54,7 @@ import shibafu.yukari.mastodon.DefaultVisibilityCache
 import shibafu.yukari.mastodon.FetchDefaultVisibilityTask
 import shibafu.yukari.mastodon.MastodonApi
 import shibafu.yukari.media2.Media
-import shibafu.yukari.service.CacheCleanerService
+import shibafu.yukari.worker.CacheCleanerWorker
 import shibafu.yukari.twitter.TwitterApi
 import shibafu.yukari.twitter.TwitterProvider
 import shibafu.yukari.util.CompatUtil
@@ -165,7 +165,7 @@ class App : Application(), TimelineHubProvider, ApiCollectionProvider, StreamCol
                 statusLoader.cancelAll()
 
                 Log.d(LOG_TAG, "[onStop] enqueue cache cleaner service")
-                CacheCleanerService.enqueueWork(applicationContext)
+                CacheCleanerWorker.enqueueWork(applicationContext)
 
                 System.gc()
 

--- a/Yukari/src/main/java/shibafu/yukari/core/App.kt
+++ b/Yukari/src/main/java/shibafu/yukari/core/App.kt
@@ -184,6 +184,7 @@ class App : Application(), TimelineHubProvider, ApiCollectionProvider, StreamCol
         if (CompatUtil.getProcessName() == packageName) {
             processLifecycleOwner.lifecycle.addObserver(streamManager)
 
+            // TODO: これMainActivityの起動時に行うべき
             // Mastodon: default visibilityの取得
             for (user in accountManager.users) {
                 if (user.Provider.apiType == Provider.API_MASTODON) {

--- a/Yukari/src/main/java/shibafu/yukari/mastodon/FetchDefaultVisibilityTask.java
+++ b/Yukari/src/main/java/shibafu/yukari/mastodon/FetchDefaultVisibilityTask.java
@@ -1,5 +1,7 @@
 package shibafu.yukari.mastodon;
 
+import android.util.Log;
+
 import com.google.gson.Gson;
 import com.google.gson.reflect.TypeToken;
 import com.sys1yagi.mastodon4j.MastodonClient;
@@ -14,6 +16,8 @@ import shibafu.yukari.entity.StatusDraft;
 import shibafu.yukari.linkage.ApiCollectionProvider;
 
 public class FetchDefaultVisibilityTask extends SimpleAsyncTask {
+    private static final String LOG_TAG = "FetchDefaultVisibilityTask";
+
     private final ApiCollectionProvider apiCollectionProvider;
     private final DefaultVisibilityCache defaultVisibilityCache;
     private final AuthUserRecord aur;
@@ -28,6 +32,7 @@ public class FetchDefaultVisibilityTask extends SimpleAsyncTask {
     protected Void doInBackground(Void... voids) {
         MastodonClient client = (MastodonClient) apiCollectionProvider.getProviderApi(Provider.API_MASTODON).getApiClient(aur);
         try {
+            Log.d(LOG_TAG, String.format("[%d] Fetching", aur.InternalId));
             Response response = client.get("preferences", null, "v1");
             if (response.isSuccessful()) {
                 String body = response.body().string();
@@ -35,6 +40,7 @@ public class FetchDefaultVisibilityTask extends SimpleAsyncTask {
                 }.getType());
                 Object maybeVisibility = prefs.get("posting:default:visibility");
                 if (maybeVisibility instanceof String) {
+                    Log.d(LOG_TAG, String.format("[%d] posting:default:visibility => %s", aur.InternalId, maybeVisibility));
                     switch ((String) maybeVisibility) {
                         case "public":
                             defaultVisibilityCache.set(aur.ScreenName, StatusDraft.Visibility.PUBLIC);

--- a/Yukari/src/main/java/shibafu/yukari/service/CacheCleanerService.java
+++ b/Yukari/src/main/java/shibafu/yukari/service/CacheCleanerService.java
@@ -1,16 +1,20 @@
 package shibafu.yukari.service;
 
 import android.content.Context;
-import android.content.Intent;
 import android.content.SharedPreferences;
 import android.net.Uri;
 import android.os.Environment;
 import android.preference.PreferenceManager;
 import androidx.annotation.NonNull;
-import androidx.core.app.JobIntentService;
+import androidx.work.ExistingWorkPolicy;
+import androidx.work.OneTimeWorkRequest;
+import androidx.work.WorkManager;
+import androidx.work.Worker;
+import androidx.work.WorkerParameters;
+
 import android.text.format.DateUtils;
 import android.util.Log;
-import shibafu.yukari.common.JobSchedulerId;
+
 import shibafu.yukari.common.bitmapcache.BitmapCache;
 import shibafu.yukari.database.CentralDatabase;
 
@@ -25,7 +29,8 @@ import java.util.stream.Collectors;
 /**
  * Created by shibafu on 14/03/04.
  */
-public class CacheCleanerService extends JobIntentService {
+public class CacheCleanerService extends Worker {
+    private static final String UNIQUE_WORK_NAME = "CACHE_CLEANER";
 
     private static final Comparator<File> COMPARATOR = (lhs, rhs) -> {
         long sub = rhs.lastModified() - lhs.lastModified();
@@ -35,18 +40,37 @@ public class CacheCleanerService extends JobIntentService {
     };
 
     public static void enqueueWork(Context context) {
-        enqueueWork(context, CacheCleanerService.class, JobSchedulerId.JOB_CACHE_CLEANER, new Intent());
+        OneTimeWorkRequest request = new OneTimeWorkRequest.Builder(CacheCleanerService.class).build();
+        WorkManager.getInstance(context).enqueueUniqueWork(UNIQUE_WORK_NAME, ExistingWorkPolicy.KEEP, request);
     }
 
+    public CacheCleanerService(@NonNull Context context, @NonNull WorkerParameters workerParams) {
+        super(context, workerParams);
+    }
+
+    @NonNull
     @Override
-    protected void onHandleWork(@NonNull Intent intent) {
-        SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(this);
+    public Result doWork() {
+        try {
+            Log.d("CacheCleanerService", "Cleaning cache...");
+            perform();
+            Log.d("CacheCleanerService", "Cleaning cache done.");
+            return Result.success();
+        } catch (Exception e) {
+            Log.e("CacheCleanerService", "Failed to clean cache.", e);
+            return Result.failure();
+        }
+    }
+
+    private void perform() {
+        Context context = getApplicationContext();
+        SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(context);
         File cacheRoot;
         if (Environment.getExternalStorageState().equals(Environment.MEDIA_MOUNTED)) {
-            cacheRoot = getExternalCacheDir();
+            cacheRoot = context.getExternalCacheDir();
         }
         else {
-            cacheRoot = getCacheDir();
+            cacheRoot = context.getCacheDir();
         }
         String[] categories = {
                 BitmapCache.PROFILE_ICON_CACHE,
@@ -61,7 +85,7 @@ public class CacheCleanerService extends JobIntentService {
         for (int i = 0; i < categories.length; ++i) {
             expirations.addAll(findExpirationCaches(new File(cacheRoot, categories[i]), limits[i] * 1024 * 1024));
         }
-        File[] tmpFiles = getExternalCacheDir().listFiles((dir, filename) -> filename.endsWith(".tmp"));
+        File[] tmpFiles = context.getExternalCacheDir().listFiles((dir, filename) -> filename.endsWith(".tmp"));
         long currentTimeMillis = System.currentTimeMillis();
         for (File tmpFile : tmpFiles) {
             if (tmpFile.lastModified() < currentTimeMillis - 86400000) {
@@ -123,7 +147,7 @@ public class CacheCleanerService extends JobIntentService {
             return;
         }
 
-        File attachesDir = new File(getExternalFilesDir(null), "attaches");
+        File attachesDir = new File(getApplicationContext().getExternalFilesDir(null), "attaches");
         if (!attachesDir.exists()) {
             return;
         }

--- a/Yukari/src/main/java/shibafu/yukari/util/CompatUtil.java
+++ b/Yukari/src/main/java/shibafu/yukari/util/CompatUtil.java
@@ -1,14 +1,8 @@
 package shibafu.yukari.util;
 
-import android.annotation.SuppressLint;
-import android.app.Application;
 import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
-import android.os.Build;
-
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 
 /**
  * Created by shibafu on 15/06/03.
@@ -22,24 +16,5 @@ public class CompatUtil {
      */
     public static PendingIntent getEmptyPendingIntent(Context context) {
         return PendingIntent.getActivity(context, 0, new Intent(), PendingIntent.FLAG_IMMUTABLE);
-    }
-
-    // https://stackoverflow.com/a/55842542
-    public static String getProcessName() {
-        if (Build.VERSION.SDK_INT >= 28)
-            return Application.getProcessName();
-
-        // Using the same technique as Application.getProcessName() for older devices
-        // Using reflection since ActivityThread is an internal API
-
-        try {
-            @SuppressLint("PrivateApi")
-            Class<?> activityThread = Class.forName("android.app.ActivityThread");
-            @SuppressLint("DiscouragedPrivateApi")
-            Method getProcessName = activityThread.getDeclaredMethod("currentProcessName");
-            return (String) getProcessName.invoke(null);
-        } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
-            throw new RuntimeException(e);
-        }
     }
 }

--- a/Yukari/src/main/java/shibafu/yukari/worker/CacheCleanerWorker.java
+++ b/Yukari/src/main/java/shibafu/yukari/worker/CacheCleanerWorker.java
@@ -1,4 +1,4 @@
-package shibafu.yukari.service;
+package shibafu.yukari.worker;
 
 import android.content.Context;
 import android.content.SharedPreferences;
@@ -29,7 +29,8 @@ import java.util.stream.Collectors;
 /**
  * Created by shibafu on 14/03/04.
  */
-public class CacheCleanerService extends Worker {
+public class CacheCleanerWorker extends Worker {
+    private static final String LOG_TAG = "CacheCleanerWorker";
     private static final String UNIQUE_WORK_NAME = "CACHE_CLEANER";
 
     private static final Comparator<File> COMPARATOR = (lhs, rhs) -> {
@@ -40,11 +41,11 @@ public class CacheCleanerService extends Worker {
     };
 
     public static void enqueueWork(Context context) {
-        OneTimeWorkRequest request = new OneTimeWorkRequest.Builder(CacheCleanerService.class).build();
+        OneTimeWorkRequest request = new OneTimeWorkRequest.Builder(CacheCleanerWorker.class).build();
         WorkManager.getInstance(context).enqueueUniqueWork(UNIQUE_WORK_NAME, ExistingWorkPolicy.KEEP, request);
     }
 
-    public CacheCleanerService(@NonNull Context context, @NonNull WorkerParameters workerParams) {
+    public CacheCleanerWorker(@NonNull Context context, @NonNull WorkerParameters workerParams) {
         super(context, workerParams);
     }
 
@@ -52,12 +53,12 @@ public class CacheCleanerService extends Worker {
     @Override
     public Result doWork() {
         try {
-            Log.d("CacheCleanerService", "Cleaning cache...");
+            Log.d(LOG_TAG, "Cleaning cache...");
             perform();
-            Log.d("CacheCleanerService", "Cleaning cache done.");
+            Log.d(LOG_TAG, "Cleaning cache done.");
             return Result.success();
         } catch (Exception e) {
-            Log.e("CacheCleanerService", "Failed to clean cache.", e);
+            Log.e(LOG_TAG, "Failed to clean cache.", e);
             return Result.failure();
         }
     }
@@ -94,7 +95,7 @@ public class CacheCleanerService extends Worker {
         }
 
         for (File f : expirations) {
-            Log.d("CacheCleanerService", "Deleting: " + f.getAbsolutePath());
+            Log.d(LOG_TAG, "Deleting: " + f.getAbsolutePath());
             f.delete();
         }
 
@@ -179,7 +180,7 @@ public class CacheCleanerService extends Worker {
             if (file.lastModified() < before1Day) {
                 String fileUri = Uri.fromFile(file).toString();
                 if (!usingUris.contains(fileUri)) {
-                    Log.d("CacheCleanerService", "Deleting: " + file.getAbsolutePath());
+                    Log.d(LOG_TAG, "Deleting: " + file.getAbsolutePath());
                     file.delete();
                 }
             }


### PR DESCRIPTION
非推奨のJobIntentServiceを使って実装されていたCacheCleanerServiceを、WorkManager Workerに置き換えた。

今まではプロセスを分離して実行していたが、WorkManager対応に伴い廃止することとなった。  
そのため、メインプロセスを判定して場合分けしていた他の処理にも若干の変更が発生した。